### PR TITLE
Always injects file name into the class nodes

### DIFF
--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -117,6 +117,8 @@ class ReflectionEngine
 
         foreach ($namespaceNodes as $namespaceLevelNode) {
             if ($namespaceLevelNode instanceof ClassLike && $namespaceLevelNode->name == $className) {
+                $namespaceLevelNode->setAttribute('fileName', $classFileName);
+
                 return $namespaceLevelNode;
             }
         }


### PR DESCRIPTION
This is needed to correctly work with parent classes