### PR TITLE
Limit number of cached files (with a setting)

### DIFF
--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -37,6 +37,11 @@ class ReflectionEngine
     protected static $parsedFiles = array();
 
     /**
+     * @var null|integer
+     */
+    protected static $maximumCachedFiles;
+
+    /**
      * @var null|Parser
      */
     protected static $parser = null;
@@ -64,6 +69,18 @@ class ReflectionEngine
         $traverser->addVisitor(new NameResolver());
 
         self::$locator = $locator;
+    }
+
+    /**
+     * Limits number of files, that can be cached at any given moment
+     *
+     * @param integer $newLimit New limit
+     *
+     * @return void
+     */
+    public static function setMaximumCachedFiles($newLimit)
+    {
+        self::$maximumCachedFiles = $newLimit;
     }
 
     /**
@@ -186,6 +203,10 @@ class ReflectionEngine
     {
         if (isset(self::$parsedFiles[$fileName])) {
             return self::$parsedFiles[$fileName];
+        }
+
+        if (isset(self::$maximumCachedFiles) && (count(self::$parsedFiles) === self::$maximumCachedFiles)) {
+            array_shift(self::$parsedFiles);
         }
 
         if (!isset($fileContent)) {


### PR DESCRIPTION
I've decided to clear all parsed files, when limit is reached instead just removing last parsed file. This technique is looking more promising for cases, when you parse several large files upfront and can't lower memory usage, because they can't be removed later.

Closes #18 