### PR TITLE
Fixing notice, when using "ReflectionClass::hasConstant" method

### DIFF
--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -588,7 +588,7 @@ trait ReflectionClassLikeTrait
     public function hasConstant($name)
     {
         $constants   = $this->getConstants();
-        $hasConstant = isset($constants[$name]) || array_key_exists($constants, $name);
+        $hasConstant = isset($constants[$name]) || array_key_exists($name, $constants);
 
         return $hasConstant;
     }


### PR DESCRIPTION
When checking class constant has `NULL` as it's value and it's being checked using `ReflectionClass::hasConstant` method then there will be a notice and constant will be returned as non-existent.

This happens, because `array_key_exists` function has different argument order.

Most likely tests doesn't cover this use case. I've found this code in Symfony framework.

P.S.
If tests are needed, then I'm happy to provide them if you'd show me some examples. I'm new to library and therefore need some assistance please.