### PR TITLE
Add tests for "ReflectionClass::hasConstant" and "ReflectionClass::getConstant" methods

### DIFF
--- a/tests/ReflectionClassTest.php
+++ b/tests/ReflectionClassTest.php
@@ -300,4 +300,22 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             );
         }
     }
+
+    public function testHasConstant()
+    {
+        $parsedRefClass   = $this->parsedRefFileNamespace->getClass(ClassWithScalarConstants::class);
+        $originalRefClass = new \ReflectionClass(ClassWithScalarConstants::class);
+
+        $this->assertSame($originalRefClass->hasConstant('D'), $parsedRefClass->hasConstant('D'));
+        $this->assertSame($originalRefClass->hasConstant('E'), $parsedRefClass->hasConstant('E'));
+    }
+
+    public function testGetConstant()
+    {
+        $parsedRefClass   = $this->parsedRefFileNamespace->getClass(ClassWithScalarConstants::class);
+        $originalRefClass = new \ReflectionClass(ClassWithScalarConstants::class);
+
+        $this->assertSame($originalRefClass->getConstant('D'), $parsedRefClass->getConstant('D'));
+        $this->assertSame($originalRefClass->getConstant('E'), $parsedRefClass->getConstant('E'));
+    }
 }

--- a/tests/Stub/FileWithClasses55.php
+++ b/tests/Stub/FileWithClasses55.php
@@ -126,6 +126,7 @@ class ClassWithScalarConstants
     const B = 42.0;
     const C = 'foo';
     const D = false;
+    const E = null;
 }
 
 class ClassWithMagicConstants


### PR DESCRIPTION
While adding tests for `ReflectionClass::hasConstant`, that was fixed in #25 I've also found out, that `ReflectionClass::getConstant` isn't directly tested as well. So I've added tests for it as well.

Related to #25