### PR TITLE
Adding test for "ComposerLocator"

### DIFF
--- a/tests/Locator/ComposerLocatorTest.php
+++ b/tests/Locator/ComposerLocatorTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace Go\ParserReflection\Locator;
+
+use Go\ParserReflection\ReflectionClass;
+
+class ComposerLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLocateClass()
+    {
+        $locator = new ComposerLocator();
+
+        $reflectionClass = new \ReflectionClass(ReflectionClass::class);
+
+        $this->assertSame(
+            $reflectionClass->getFileName(),
+            realpath($locator->locateClass(ReflectionClass::class))
+        );
+    }
+}


### PR DESCRIPTION
The `realpath` call is needed to resolve relative path, that Composer autoloader is building since PHP 5.6. The related Composer feature is called static autoloader.