### PR TITLE
Adding "branch-alias" to "composer.json"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.x-dev"
+    }
   }
 }


### PR DESCRIPTION
When `branch-alias` present in `composer.json` it comes possible to specify version like `^1.1@dev` when requiring the library. This way project using the library will get it's dev dependency, but whoever uses that project would use live dependency instead.