### PR TITLE
bugfix

### DIFF
--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -154,7 +154,7 @@ trait ReflectionFunctionLikeTrait
         if (!isset($this->parameters)) {
             $parameters = [];
 
-            foreach ($this->functionLikeNode->getParams() as $parameterIndex => $parameterNode) {
+            foreach ($this->functionLikeNode->params as $parameterIndex => $parameterNode) {
                 $reflectionParameter = new ReflectionParameter(
                     $this->getName(),
                     $parameterNode->name,


### PR DESCRIPTION
Fatal error: Call to undefined method PhpParser\Node\Stmt\ClassMethod::getParams() in /vendor/goaop/parser-reflection/src/Traits/ReflectionFunctionLikeTrait.php on line 157