### PR TITLE
Add root namespace normalization, resolves #39

### DIFF
--- a/src/NodeVisitor/RootNamespaceNormalizer.php
+++ b/src/NodeVisitor/RootNamespaceNormalizer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Parser Reflection API
+ *
+ * @copyright Copyright 2016, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\ParserReflection\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Visitor to normalize the root namespace for the files without the namespace (root namespace)
+ *
+ * File->Namespace->Statements
+ */
+class RootNamespaceNormalizer extends NodeVisitorAbstract
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        // namespaces can be only top-level nodes, so we can scan them directly
+        foreach ($nodes as $topLevelNode) {
+            if ($topLevelNode instanceof Namespace_) {
+                // file has namespace in it, nothing to change, returning null
+                return null;
+            }
+        }
+
+        // if we don't have a namespaces at all, this is global namespace, wrap everything in it
+        $globalNamespaceNode = new Namespace_(new FullyQualified(''), $nodes);
+
+        return [$globalNamespaceNode];
+    }
+}

--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -10,6 +10,7 @@
 
 namespace Go\ParserReflection;
 
+use Go\ParserReflection\NodeVisitor\RootNamespaceNormalizer;
 use PhpParser\Lexer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
@@ -67,6 +68,7 @@ class ReflectionEngine
 
         self::$traverser = $traverser = new NodeTraverser();
         $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new RootNamespaceNormalizer());
 
         self::$locator = $locator;
     }
@@ -126,14 +128,9 @@ class ReflectionEngine
         $className      = array_pop($namespaceParts);
         $namespaceName  = join('\\', $namespaceParts);
 
-        if ($namespaceName) {
-            // we have a namespace nodes somewhere
-            $namespace      = self::parseFileNamespace($classFileName, $namespaceName);
-            $namespaceNodes = $namespace->stmts;
-        } else {
-            // global namespace
-            $namespaceNodes = self::parseFile($classFileName);
-        }
+        // we have a namespace node somewhere
+        $namespace      = self::parseFileNamespace($classFileName, $namespaceName);
+        $namespaceNodes = $namespace->stmts;
 
         foreach ($namespaceNodes as $namespaceLevelNode) {
             if ($namespaceLevelNode instanceof ClassLike && $namespaceLevelNode->name == $className) {
@@ -236,7 +233,11 @@ class ReflectionEngine
         $topLevelNodes = self::parseFile($fileName);
         // namespaces can be only top-level nodes, so we can scan them directly
         foreach ($topLevelNodes as $topLevelNode) {
-            if ($topLevelNode instanceof Namespace_ && ($topLevelNode->name->toString() == $namespaceName)) {
+            if (!$topLevelNode instanceof Namespace_) {
+                continue;
+            }
+            $topLevelNodeName = $topLevelNode->name ? $topLevelNode->name->toString() : '';
+            if ($topLevelNodeName === $namespaceName) {
                 return $topLevelNode;
             }
         }

--- a/src/ReflectionFile.php
+++ b/src/ReflectionFile.php
@@ -12,7 +12,6 @@ namespace Go\ParserReflection;
 
 
 use PhpParser\Node;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Namespace_;
 
 /**
@@ -120,7 +119,7 @@ class ReflectionFile
         // namespaces can be only top-level nodes, so we can scan them directly
         foreach ($this->topLevelNodes as $topLevelNode) {
             if ($topLevelNode instanceof Namespace_) {
-                $namespaceName = $topLevelNode->name ? $topLevelNode->name->toString() : '\\';
+                $namespaceName = $topLevelNode->name ? $topLevelNode->name->toString() : '';
 
                 $namespaces[$namespaceName] = new ReflectionFileNamespace(
                     $this->fileName,
@@ -128,12 +127,6 @@ class ReflectionFile
                     $topLevelNode
                 );
             }
-        }
-
-        if (!$namespaces) {
-            // if we don't have a namespaces at all, this is global namespace
-            $globalNamespaceNode = new Namespace_(new FullyQualified(''), $this->topLevelNodes);
-            $namespaces['\\']    = new ReflectionFileNamespace($this->fileName, '\\', $globalNamespaceNode);
         }
 
         return $namespaces;

--- a/tests/ReflectionFileTest.php
+++ b/tests/ReflectionFileTest.php
@@ -55,7 +55,7 @@ class ReflectionFileTest extends \PHPUnit_Framework_TestCase
         $fileName       = stream_resolve_include_path(__DIR__ . self::STUB_GLOBAL_FILE);
         $reflectionFile = new ReflectionFile($fileName);
 
-        $reflectionFileNamespace = $reflectionFile->getFileNamespace('\\');
+        $reflectionFileNamespace = $reflectionFile->getFileNamespace('');
         $this->assertInstanceOf(ReflectionFileNamespace::class, $reflectionFileNamespace);
     }
 }

--- a/tests/ReflectionParameterTest.php
+++ b/tests/ReflectionParameterTest.php
@@ -3,6 +3,7 @@ namespace Go\ParserReflection;
 
 use Go\ParserReflection\Stub\Foo;
 use Go\ParserReflection\Stub\SubFoo;
+use TestParametersForRootNsClass;
 
 class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 {
@@ -103,6 +104,18 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $parentParam = $parameters[1 /* parent $parentParam */]->getClass();
         $this->assertInstanceOf(\ReflectionClass::class, $parentParam);
         $this->assertSame(Foo::class, $parentParam->getName());
+    }
+
+    public function testNonConstantsResolvedForGlobalNamespace()
+    {
+        $parsedNamespace = $this->parsedRefFile->getFileNamespace('');
+        $parsedClass     = $parsedNamespace->getClass(TestParametersForRootNsClass::class);
+        $parsedFunction  = $parsedClass->getMethod('foo');
+
+        $parameters = $parsedFunction->getParameters();
+        $this->assertSame(null, $parameters[0]->getDefaultValue());
+        $this->assertSame(false, $parameters[1]->getDefaultValue());
+        $this->assertSame(true, $parameters[2]->getDefaultValue());
     }
 
     public function testGetDeclaringClassMethodReturnsObject()

--- a/tests/Stub/FileWithParameters.php
+++ b/tests/Stub/FileWithParameters.php
@@ -1,36 +1,61 @@
 <?php
 
-namespace Go\ParserReflection\Stub;
+namespace {
+    function testResolveDefaults($a=null, $b=false, $c=true) {}
 
-use Go\ParserReflection\ReflectionParameter;
-
-const TEST_PARAMETER = 42;
-
-function noParameters() {}
-function singleParameter($test) {}
-function miscParameters(
-    array $arrayParam,
-    array $arrayParamWithDefault = array(1,2,3),
-    array $arrayNullable = null,
-    callable $callableParam,
-    callable $callableNullable = null,
-    \stdClass $objectParam,
-    \stdClass $objectNullable = null,
-    ReflectionParameter $typehintedParamWithNs,
-    &$byReferenceParam,
-    &$byReferenceNullable = __CLASS__,
-    $constParam = TEST_PARAMETER,
-    $constValueParam = __NAMESPACE__, // This line is long and should be truncated
-    \Traversable $traversable
-) {}
-
-class Foo {
-    const CLASS_CONST = __CLASS__;
-
-    public function methodParam($firstParam, $optionalParam = null) {}
-    public function methodParamConst($firstParam = self::CLASS_CONST, $another = __CLASS__, $ns = TEST_PARAMETER) {}
+    class TestParametersForRootNsClass {
+        function foo($a=null, $b=false, $c=true) {}
+    }
 }
 
-class SubFoo extends Foo {
-    public function anotherMethodParam(self $selfParam, parent $parentParam) {}
+namespace Go\ParserReflection\Stub {
+
+    use Go\ParserReflection\ReflectionParameter;
+
+    const TEST_PARAMETER = 42;
+
+    function noParameters()
+    {
+    }
+
+    function singleParameter($test)
+    {
+    }
+
+    function miscParameters(
+        array $arrayParam,
+        array $arrayParamWithDefault = array(1, 2, 3),
+        array $arrayNullable = null,
+        callable $callableParam,
+        callable $callableNullable = null,
+        \stdClass $objectParam,
+        \stdClass $objectNullable = null,
+        ReflectionParameter $typehintedParamWithNs,
+        &$byReferenceParam,
+        &$byReferenceNullable = __CLASS__,
+        $constParam = TEST_PARAMETER,
+        $constValueParam = __NAMESPACE__, // This line is long and should be truncated
+        \Traversable $traversable
+    ) {
+    }
+
+    class Foo
+    {
+        const CLASS_CONST = __CLASS__;
+
+        public function methodParam($firstParam, $optionalParam = null)
+        {
+        }
+
+        public function methodParamConst($firstParam = self::CLASS_CONST, $another = __CLASS__, $ns = TEST_PARAMETER)
+        {
+        }
+    }
+
+    class SubFoo extends Foo
+    {
+        public function anotherMethodParam(self $selfParam, parent $parentParam)
+        {
+        }
+    }
 }

--- a/tests/Stub/FileWithParameters.php
+++ b/tests/Stub/FileWithParameters.php
@@ -1,10 +1,15 @@
 <?php
 
 namespace {
-    function testResolveDefaults($a=null, $b=false, $c=true) {}
+    function testResolveDefaults($a = null, $b = false, $c = true)
+    {
+    }
 
-    class TestParametersForRootNsClass {
-        function foo($a=null, $b=false, $c=true) {}
+    class TestParametersForRootNsClass
+    {
+        public function foo($a = null, $b = false, $c = true)
+        {
+        }
     }
 }
 


### PR DESCRIPTION
This PR should enable support of reflecting top-level classes without namespace with class method with default parameters, equals to one of: [true, false, null]