### PR TITLE
[NodeResolver] allow parsing of scalar expressions

### DIFF
--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -212,9 +212,8 @@ trait ReflectionClassLikeTrait
             $parentConstants = $this->recursiveCollect(function (array &$result, \ReflectionClass $instance) {
                 $result += $instance->getConstants();
             });
-            $constants = $directConstants + $parentConstants;
 
-            $this->constants = $constants;
+            $this->constants = $directConstants + $parentConstants;
         }
 
         return $this->constants;
@@ -934,7 +933,6 @@ trait ReflectionClassLikeTrait
      */
     private function findConstants()
     {
-        $constants        = array();
         $expressionSolver = new NodeExpressionResolver($this);
 
         // constants can be only top-level nodes in the class, so we can scan them directly
@@ -944,12 +942,12 @@ trait ReflectionClassLikeTrait
                 if (!empty($nodeConstants)) {
                     foreach ($nodeConstants as $nodeConstant) {
                         $expressionSolver->process($nodeConstant->value);
-                        $constants[$nodeConstant->name] = $expressionSolver->getValue();
+                        $this->constants[$nodeConstant->name] = $expressionSolver->getValue();
                     }
                 }
             }
         }
 
-        return $constants;
+        return $this->constants ?: [];
     }
 }

--- a/src/ValueResolver/NodeExpressionResolver.php
+++ b/src/ValueResolver/NodeExpressionResolver.php
@@ -263,7 +263,7 @@ class NodeExpressionResolver
         if ('class' === $constantName) {
             return $refClass->getName();
         }
-        
+
         $this->isConstant = true;
         $this->constantName = (string)$node->class . '::' . $constantName;
 
@@ -280,6 +280,149 @@ class NodeExpressionResolver
         }
 
         return $result;
+    }
+
+    protected function resolveExprBinaryOpPlus(Expr\BinaryOp\Plus $node)
+    {
+        return $this->resolve($node->left) + $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpMinus(Expr\BinaryOp\Minus $node)
+    {
+        return $this->resolve($node->left) - $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpMul(Expr\BinaryOp\Mul $node)
+    {
+        return $this->resolve($node->left) * $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpDiv(Expr\BinaryOp\Div $node)
+    {
+        return $this->resolve($node->left) / $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpMod(Expr\BinaryOp\Mod $node)
+    {
+        return $this->resolve($node->left) % $this->resolve($node->right);
+    }
+
+    protected function resolveExprBooleanNot(Expr\BooleanNot $node)
+    {
+        return !$this->resolve($node->expr);
+    }
+
+    protected function resolveExprBitwiseNot(Expr\BitwiseNot $node)
+    {
+        return ~$this->resolve($node->expr);
+    }
+
+    protected function resolveExprBinaryOpBitwiseOr(Expr\BinaryOp\BitwiseOr $node)
+    {
+        return $this->resolve($node->left) | $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpBitwiseAnd(Expr\BinaryOp\BitwiseAnd $node)
+    {
+        return $this->resolve($node->left) & $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpBitwiseXor(Expr\BinaryOp\BitwiseXor $node)
+    {
+        return $this->resolve($node->left) ^ $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpShiftLeft(Expr\BinaryOp\ShiftLeft $node)
+    {
+        return $this->resolve($node->left) << $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpShiftRight(Expr\BinaryOp\ShiftRight $node)
+    {
+        return $this->resolve($node->left) >> $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpConcat(Expr\BinaryOp\Concat $node)
+    {
+        return $this->resolve($node->left) . $this->resolve($node->right);
+    }
+
+    protected function resolveExprTernary(Expr\Ternary $node)
+    {
+        if (isset($node->if)) {
+            // Full syntax $a ? $b : $c;
+
+            return $this->resolve($node->cond) ? $this->resolve($node->if) : $this->resolve($node->else);
+        } else {
+            // Short syntax $a ?: $c;
+
+            return $this->resolve($node->cond) ?: $this->resolve($node->else);
+        }
+    }
+
+    protected function resolveExprBinaryOpSmallerOrEqual(Expr\BinaryOp\SmallerOrEqual $node)
+    {
+        return $this->resolve($node->left) <= $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpGreaterOrEqual(Expr\BinaryOp\GreaterOrEqual $node)
+    {
+        return $this->resolve($node->left) >= $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpEqual(Expr\BinaryOp\Equal $node)
+    {
+        return $this->resolve($node->left) == $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpNotEqual(Expr\BinaryOp\NotEqual $node)
+    {
+        return $this->resolve($node->left) != $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpSmaller(Expr\BinaryOp\Smaller $node)
+    {
+        return $this->resolve($node->left) < $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpGreater(Expr\BinaryOp\Greater $node)
+    {
+        return $this->resolve($node->left) > $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpIdentical(Expr\BinaryOp\Identical $node)
+    {
+        return $this->resolve($node->left) === $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpNotIdentical(Expr\BinaryOp\NotIdentical $node)
+    {
+        return $this->resolve($node->left) !== $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpBooleanAnd(Expr\BinaryOp\BooleanAnd $node)
+    {
+        return $this->resolve($node->left) && $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpLogicalAnd(Expr\BinaryOp\LogicalAnd $node)
+    {
+        return $this->resolve($node->left) and $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpBooleanOr(Expr\BinaryOp\BooleanOr $node)
+    {
+        return $this->resolve($node->left) || $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpLogicalOr(Expr\BinaryOp\LogicalOr $node)
+    {
+        return $this->resolve($node->left) or $this->resolve($node->right);
+    }
+
+    protected function resolveExprBinaryOpLogicalXor(Expr\BinaryOp\LogicalXor $node)
+    {
+        return $this->resolve($node->left) xor $this->resolve($node->right);
     }
 
     /**

--- a/tests/Stub/FileWithClasses56.php
+++ b/tests/Stub/FileWithClasses56.php
@@ -15,3 +15,70 @@ class ClassWithComplexConstantsAndInheritance extends ClassWithArrayConstants
     const K = array(1, NS_CONST56);
     const L = [self::class, ClassWithArrayConstants::A, parent::B];
 }
+
+const ONE = 1;
+
+/**
+ * The following operations are currently supported for scalar expressions:
+ *
+ * + - Addition
+ * - - Subtraction
+ * * - Multiplication
+ * / - Division
+ * % - Modulus
+ * ! - Boolean Negation
+ * ~ - Bitwise Negation
+ * | - Bitwise OR
+ * & - Bitwise AND
+ * ^ - Bitwise XOR
+ * << - Bitwise Shift Left
+ * >> - Bitwise Shift Right
+ * . - Concatenation
+ * ?: - Ternary Operator
+ * <= - Smaller or Equal
+ * => - Greater or Equal
+ * == - Equal
+ * != - Not Equal
+ * < - Smaller
+ * > - Greater
+ * === - Identical
+ * !== - Not Identical
+ * && / and - Boolean AND
+ * || / or - Boolean OR
+ * xor - Boolean XOR
+ *
+ * Also supported is grouping static operations: (1 + 2) * 3.
+ */
+class ClassWithConstantExpressions
+{
+    const ADDITION            = ONE + 1;
+    const SUBTRACTION         = 2 - ONE;
+    const MULTIPLICATION      = ONE * 2;
+    const DIVISION            = ONE / 2;
+    const MODULUS             = ONE % 2;
+    const BOOLEAN_NEGATION    = !ONE;
+    const BITWISE_NEGATION    = ~ONE;
+    const BITWISE_OR          = ONE | 2;
+    const BITWISE_AND         = ONE & 2;
+    const BITWISE_XOR         = ONE ^ 2;
+    const BITWISE_SHIFT_LEFT  = ONE << 3;
+    const BITWISE_SHIFT_RIGHT = ONE >> 3;
+    const CONCATENATION       = 'Value of shift left is ' . self::BITWISE_SHIFT_LEFT;
+    const TERNARY_OPERATOR    = true ?: false;
+    const SMALLER_OR_EQUAL    = ONE <= 2;
+    const GREATER_OR_EQUAL    = ONE >= 2;
+    const EQUAL               = ONE == true;
+    const NOT_EQUAL           = ONE != 2;
+    const SMALLER             = ONE < 2;
+    const GREATER             = ONE > 2;
+    const IDENTICAL           = ONE === true;
+    const NOT_IDENTICAL       = ONE !== true;
+    const BOOLEAN_AND         = ONE && false;
+    const LOGICAL_AND         = ONE and false;
+    const BOOLEAN_OR          = ONE || true;
+    const LOGICAL_OR          = ONE or true;
+    const LOGICAL_XOR         = ONE xor true;
+    const GROUPING            = (ONE + 2) * 3;
+
+    const REFERENCE = self::ADDITION;
+}


### PR DESCRIPTION
This PR introduces support for evaluation of scalar expressions in constants and parameters for PHP>=5.6