### PR TITLE
Implement ReflectionFile->isStrictMode check for the strict_types

### DIFF
--- a/src/ReflectionFile.php
+++ b/src/ReflectionFile.php
@@ -110,6 +110,27 @@ class ReflectionFile
     }
 
     /**
+     * Checks if the current file is in strict mode
+     *
+     * @return bool
+     */
+    public function isStrictMode()
+    {
+        // declare statement for the strict_types can be only top-level node
+        $topLevelNode = reset($this->topLevelNodes);
+        if (!$topLevelNode instanceof Node\Stmt\Declare_) {
+            return false;
+        }
+
+        $declareStatement = reset($topLevelNode->declares);
+        $isStrictTypeKey  = $declareStatement->key === 'strict_types';
+        $isScalarValue    = $declareStatement->value instanceof Node\Scalar\LNumber;
+        $isStrictMode     = $isStrictTypeKey && $isScalarValue && $declareStatement->value->value === 1;
+
+        return $isStrictMode;
+    }
+
+    /**
      * Searches for file namespaces in the given AST
      *
      * @return array|ReflectionFileNamespace[]

--- a/tests/ReflectionFileTest.php
+++ b/tests/ReflectionFileTest.php
@@ -58,4 +58,30 @@ class ReflectionFileTest extends \PHPUnit_Framework_TestCase
         $reflectionFileNamespace = $reflectionFile->getFileNamespace('');
         $this->assertInstanceOf(ReflectionFileNamespace::class, $reflectionFileNamespace);
     }
+
+    /**
+     * Tests if strict mode detected correctly
+     *
+     * @param string $fileName Filename to analyse
+     * @param bool $shouldBeStrict
+     *
+     * @dataProvider fileNameProvider
+     */
+    public function testIsStrictType($fileName, $shouldBeStrict)
+    {
+        $fileName       = stream_resolve_include_path(__DIR__ . $fileName);
+        $reflectionFile = new ReflectionFile($fileName);
+
+        $this->assertSame($shouldBeStrict, $reflectionFile->isStrictMode());
+    }
+
+    public function fileNameProvider()
+    {
+        return [
+            '/Stub/FileWithClasses56.php'       => ['/Stub/FileWithClasses56.php', false],
+            '/Stub/FileWithClasses70.php'       => ['/Stub/FileWithClasses70.php', false],
+            '/Stub/FileWithClasses71.php'       => ['/Stub/FileWithClasses71.php', true],
+            '/Stub/FileWithGlobalNamespace.php' => ['/Stub/FileWithGlobalNamespace.php', true],
+        ];
+    }
 }

--- a/tests/Stub/FileWithClasses70.php
+++ b/tests/Stub/FileWithClasses70.php
@@ -7,6 +7,7 @@
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+declare(strict_types=0);
 
 namespace Go\ParserReflection\Stub;
 

--- a/tests/Stub/FileWithClasses71.php
+++ b/tests/Stub/FileWithClasses71.php
@@ -7,6 +7,7 @@
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
+declare(strict_types=1);
 
 namespace Go\ParserReflection\Stub;
 

--- a/tests/Stub/FileWithGlobalNamespace.php
+++ b/tests/Stub/FileWithGlobalNamespace.php
@@ -2,6 +2,7 @@
 /**
  * This is test file with global namespace
  */
+declare(strict_types=1);
 
 /**
  * @internal


### PR DESCRIPTION
Provides an API for checking the `strict_types` mode in files via `ReflectionFile->isStrictMode()`. This API can be useful for proxy generation to keep the correct execution mode for scalar values.