### PR TITLE
Support for Composer classmap autoloading

### DIFF
--- a/src/Locator/ComposerLocator.php
+++ b/src/Locator/ComposerLocator.php
@@ -51,7 +51,7 @@ class ComposerLocator implements LocatorInterface
      */
     public function locateClass($className)
     {
-        $filePath = $this->loader->findFile($className);
+        $filePath = $this->loader->findFile(ltrim($className, '\\'));
         if (!empty($filePath)) {
             $filePath = PathResolver::realpath($filePath);
         }


### PR DESCRIPTION
In the classmap autoloader mode of Composer, class names are written without the leading slash, but `ComposerLocator` passes them with the leading slash.

This leads to the following error when I try to use, for example, AspectMock library on Yii 1.1-based PHP project with PHP version 7.1 (see screenshot):

![2017-01-28_19-53-34](https://cloud.githubusercontent.com/assets/967464/22406074/b174e578-e65c-11e6-8134-eed785e9c3b6.png)

Feel free to ask me for more details.

All 2000+ tests are still passing and I believe this change actually fixes a long-standing problem instead of creating another one.