### PR TITLE
Static ReflectionEngine replaced with injected ReflectionParser

### DIFF
--- a/src/NodeVisitor/StaticVariablesCollector.php
+++ b/src/NodeVisitor/StaticVariablesCollector.php
@@ -10,6 +10,8 @@
 
 namespace Go\ParserReflection\NodeVisitor;
 
+use Go\ParserReflection\ReflectionEngine;
+use Go\ParserReflection\ReflectionParser;
 use Go\ParserReflection\ValueResolver\NodeExpressionResolver;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
@@ -27,6 +29,11 @@ class StaticVariablesCollector extends NodeVisitorAbstract
      */
     private $context;
 
+    /**
+     * @var ReflectionParser
+     */
+    private $reflectionParser;
+
     private $staticVariables = [];
 
     /**
@@ -34,9 +41,10 @@ class StaticVariablesCollector extends NodeVisitorAbstract
      *
      * @param mixed $context Reflection context, eg. ReflectionClass, ReflectionMethod, etc
      */
-    public function __construct($context)
+    public function __construct($context, ReflectionParser $reflectionParser = null)
     {
         $this->context = $context;
+        $this->reflectionParser = $reflectionParser ?: ReflectionEngine::getReflectionParser();
     }
 
     /**
@@ -50,7 +58,7 @@ class StaticVariablesCollector extends NodeVisitorAbstract
         }
 
         if ($node instanceof Node\Stmt\Static_) {
-            $expressionSolver = new NodeExpressionResolver($this->context);
+            $expressionSolver = new NodeExpressionResolver($this->context, $this->reflectionParser);
             $staticVariables  = $node->vars;
             foreach ($staticVariables as $staticVariable) {
                 $expr = $staticVariable->default;

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -54,7 +54,7 @@ class ReflectionClass extends InternalReflectionClass
      *
      * @return array|\ReflectionClass[] List of reflections of interfaces
      */
-    public static function collectInterfacesFromClassNode(ClassLike $classLikeNode)
+    public static function collectInterfacesFromClassNode(ClassLike $classLikeNode, ReflectionParser $reflectionParser)
     {
         $interfaces = [];
 
@@ -66,9 +66,7 @@ class ReflectionClass extends InternalReflectionClass
             foreach ($implementsList as $implementNode) {
                 if ($implementNode instanceof FullyQualified) {
                     $implementName  = $implementNode->toString();
-                    $interface      = interface_exists($implementName, false)
-                        ? new parent($implementName)
-                        : new static($implementName, null, $this->reflectionParser);
+                    $interface      = $reflectionParser->getClassReflection($implementName);
                     $interfaces[$implementName] = $interface;
                 }
             }
@@ -86,7 +84,7 @@ class ReflectionClass extends InternalReflectionClass
      *
      * @return array|\ReflectionClass[] List of reflections of traits
      */
-    public static function collectTraitsFromClassNode(ClassLike $classLikeNode, array &$traitAdaptations)
+    public static function collectTraitsFromClassNode(ClassLike $classLikeNode, array &$traitAdaptations, ReflectionParser $reflectionParser)
     {
         $traits = [];
 
@@ -96,9 +94,7 @@ class ReflectionClass extends InternalReflectionClass
                     foreach ($classLevelNode->traits as $classTraitName) {
                         if ($classTraitName instanceof FullyQualified) {
                             $traitName          = $classTraitName->toString();
-                            $trait              = trait_exists($traitName, false)
-                                ? new parent($traitName)
-                                : new static($traitName, null, $this->reflectionParser);
+                            $trait              = $reflectionParser->getClassReflection($traitName);
                             $traits[$traitName] = $trait;
                         }
                     }

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -30,8 +30,9 @@ class ReflectionClass extends InternalReflectionClass
      *
      * @param string|object $argument Class name or instance of object
      * @param ClassLike $classLikeNode AST node for class
+     * @param ReflectionParser $reflectionParser AST parser
      */
-    public function __construct($argument, ClassLike $classLikeNode = null)
+    public function __construct($argument, ClassLike $classLikeNode = null, ReflectionParser $reflectionParser = null)
     {
         $fullClassName       = is_object($argument) ? get_class($argument) : $argument;
         $namespaceParts      = explode('\\', $fullClassName);
@@ -40,14 +41,16 @@ class ReflectionClass extends InternalReflectionClass
         unset($this->name);
 
         $this->namespaceName = join('\\', $namespaceParts);
+        $this->reflectionParser = $reflectionParser ?: ReflectionEngine::getReflectionParser();
 
-        $this->classLikeNode = $classLikeNode ?: ReflectionEngine::parseClass($fullClassName);
+        $this->classLikeNode = $classLikeNode ?: $this->reflectionParser->parseClass($fullClassName);
     }
 
     /**
      * Parses interfaces from the concrete class node
      *
      * @param ClassLike $classLikeNode Class-like node
+     * @param ReflectionParser $reflectionParser AST parser
      *
      * @return array|\ReflectionClass[] List of reflections of interfaces
      */
@@ -65,7 +68,7 @@ class ReflectionClass extends InternalReflectionClass
                     $implementName  = $implementNode->toString();
                     $interface      = interface_exists($implementName, false)
                         ? new parent($implementName)
-                        : new static($implementName);
+                        : new static($implementName, null, $this->reflectionParser);
                     $interfaces[$implementName] = $interface;
                 }
             }
@@ -79,6 +82,7 @@ class ReflectionClass extends InternalReflectionClass
      *
      * @param ClassLike $classLikeNode Class-like node
      * @param array     $traitAdaptations List of method adaptations
+     * @param ReflectionParser $reflectionParser AST parser
      *
      * @return array|\ReflectionClass[] List of reflections of traits
      */
@@ -94,7 +98,7 @@ class ReflectionClass extends InternalReflectionClass
                             $traitName          = $classTraitName->toString();
                             $trait              = trait_exists($traitName, false)
                                 ? new parent($traitName)
-                                : new static($traitName);
+                                : new static($traitName, null, $this->reflectionParser);
                             $traits[$traitName] = $trait;
                         }
                     }

--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -60,6 +60,14 @@ class ReflectionEngine
     }
 
     /**
+     * @return ReflectionParser
+     */
+    public static function getReflectionParser()
+    {
+        return self::$reflectionParser;
+    }
+
+    /**
      * Limits number of files, that can be cached at any given moment
      *
      * @param integer $newLimit New limit

--- a/src/ReflectionFile.php
+++ b/src/ReflectionFile.php
@@ -43,16 +43,23 @@ class ReflectionFile
     private $topLevelNodes;
 
     /**
+     * @var ReflectionParser
+     */
+    private $reflectionParser;
+
+    /**
      * ReflectionFile constructor.
      *
      * @param string $fileName Name of the file to reflect
      * @param null|array|Node[] $topLevelNodes Optional corresponding list of AST nodes for that file
+     * @param ReflectionParser $reflectionParser AST parser
      */
-    public function __construct($fileName, $topLevelNodes = null)
+    public function __construct($fileName, $topLevelNodes = null, ReflectionParser $reflectionParser = null)
     {
         $fileName            = PathResolver::realpath($fileName);
         $this->fileName      = $fileName;
-        $this->topLevelNodes = $topLevelNodes ?: ReflectionEngine::parseFile($fileName);
+        $this->reflectionParser = $reflectionParser ?: ReflectionEngine::getReflectionParser();
+        $this->topLevelNodes = $topLevelNodes ?: $this->reflectionParser->parseFile($fileName);
     }
 
     /**
@@ -147,7 +154,8 @@ class ReflectionFile
                 $namespaces[$namespaceName] = new ReflectionFileNamespace(
                     $this->fileName,
                     $namespaceName,
-                    $topLevelNode
+                    $topLevelNode,
+                    $this->reflectionParser
                 );
             }
         }

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -44,17 +44,20 @@ class ReflectionMethod extends BaseReflectionMethod
      * @param string $methodName Name of the method
      * @param ClassMethod $classMethodNode AST-node for method
      * @param ReflectionClass $declaringClass Optional declaring class
+     * @param ReflectionParser $reflectionParser AST parser
      */
     public function __construct(
         $className,
         $methodName,
         ClassMethod $classMethodNode = null,
-        ReflectionClass $declaringClass = null
+        ReflectionClass $declaringClass = null,
+        ReflectionParser $reflectionParser = null
     ) {
         //for some reason, ReflectionMethod->getNamespaceName in php always returns '', so we shouldn't use it too
         $this->className        = $className;
         $this->declaringClass   = $declaringClass;
-        $this->functionLikeNode = $classMethodNode ?: ReflectionEngine::parseClassMethod($className, $methodName);
+        $this->reflectionParser = $reflectionParser ?: ReflectionEngine::getReflectionParser();
+        $this->functionLikeNode = $classMethodNode ?: $this->reflectionParser->parseClassMethod($className, $methodName);
 
         // Let's unset original read-only properties to have a control over them via __get
         unset($this->name, $this->class);
@@ -281,10 +284,11 @@ class ReflectionMethod extends BaseReflectionMethod
      *
      * @param ClassLike $classLikeNode Class-like node
      * @param ReflectionClass $reflectionClass Reflection of the class
+     * @param ReflectionParser $reflectionParser AST parser
      *
      * @return array|ReflectionMethod[]
      */
-    public static function collectFromClassNode(ClassLike $classLikeNode, ReflectionClass $reflectionClass)
+    public static function collectFromClassNode(ClassLike $classLikeNode, ReflectionClass $reflectionClass, ReflectionParser $reflectionParser)
     {
         $methods = [];
 
@@ -297,7 +301,8 @@ class ReflectionMethod extends BaseReflectionMethod
                     $reflectionClass->name,
                     $methodName,
                     $classLevelNode,
-                    $reflectionClass
+                    $reflectionClass,
+                    $reflectionParser
                 );
             }
         }

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -136,7 +136,9 @@ class ReflectionMethod extends BaseReflectionMethod
      */
     public function getDeclaringClass()
     {
-        return isset($this->declaringClass) ? $this->declaringClass : new ReflectionClass($this->className);
+        return isset($this->declaringClass)
+            ? $this->declaringClass
+            : $this->reflectionParser->getClassReflection($this->className);
     }
 
     /**

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -205,9 +205,7 @@ class ReflectionParameter extends BaseReflectionParameter
                 throw new ReflectionException("Can not resolve a class name for parameter");
             }
             $className   = $parameterType->toString();
-            $classOrInterfaceExists = class_exists($className, false) || interface_exists($className, false);
-
-            return $classOrInterfaceExists ? new \ReflectionClass($className) : new ReflectionClass($className);
+            return $this->reflectionParser->getClassReflection($className);
         }
 
         return null;

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -67,6 +67,11 @@ class ReflectionParameter extends BaseReflectionParameter
     private $parameterNode;
 
     /**
+     * @var ReflectionParser
+     */
+    private $reflectionParser;
+
+    /**
      * Initializes a reflection for the property
      *
      * @param string|array $unusedFunctionName Name of the function/method
@@ -74,13 +79,15 @@ class ReflectionParameter extends BaseReflectionParameter
      * @param Param $parameterNode Parameter definition node
      * @param int $parameterIndex Index of parameter
      * @param \ReflectionFunctionAbstract $declaringFunction
+     * @param ReflectionParser $reflectionParser AST parser
      */
     public function __construct(
         $unusedFunctionName,
         $parameterName,
         Param $parameterNode = null,
         $parameterIndex = 0,
-        \ReflectionFunctionAbstract $declaringFunction = null
+        \ReflectionFunctionAbstract $declaringFunction = null,
+        ReflectionParser $reflectionParser = null
     ) {
         // Let's unset original read-only property to have a control over it via __get
         unset($this->name);
@@ -88,6 +95,7 @@ class ReflectionParameter extends BaseReflectionParameter
         $this->parameterNode     = $parameterNode;
         $this->parameterIndex    = $parameterIndex;
         $this->declaringFunction = $declaringFunction;
+        $this->reflectionParser           = $reflectionParser ?: ReflectionEngine::getReflectionParser();
 
         if ($this->isDefaultValueAvailable()) {
             if ($declaringFunction instanceof \ReflectionMethod) {
@@ -96,7 +104,7 @@ class ReflectionParameter extends BaseReflectionParameter
                 $context = $declaringFunction;
             };
 
-            $expressionSolver = new NodeExpressionResolver($context);
+            $expressionSolver = new NodeExpressionResolver($context, $this->reflectionParser);
             $expressionSolver->process($this->parameterNode->default);
             $this->defaultValue             = $expressionSolver->getValue();
             $this->isDefaultValueConstant   = $expressionSolver->isConstant();

--- a/src/ReflectionParser.php
+++ b/src/ReflectionParser.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Parser Reflection API
+ *
+ * @copyright Copyright 2015, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\ParserReflection;
+
+use Go\ParserReflection\Instrument\PathResolver;
+use Go\ParserReflection\NodeVisitor\RootNamespaceNormalizer;
+use PhpParser\Lexer;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+/**
+ * AST-based reflection engine, powered by PHP-Parser
+ */
+class ReflectionParser
+{
+    /**
+     * @var null|LocatorInterface
+     */
+    protected $locator = null;
+
+    /**
+     * @var array|Node[]
+     */
+    protected $parsedFiles = array();
+
+    /**
+     * @var null|integer
+     */
+    protected $maximumCachedFiles;
+
+    /**
+     * @var null|Parser
+     */
+    protected $parser = null;
+
+    /**
+     * @var null|NodeTraverser
+     */
+    protected $traverser = null;
+
+
+    public function __construct(LocatorInterface $locator)
+    {
+        $refParser   = new \ReflectionClass(Parser::class);
+        $isNewParser = $refParser->isInterface();
+        if (!$isNewParser) {
+            $this->parser = new Parser(new Lexer(['usedAttributes' => [
+                'comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos', 'startFilePos', 'endFilePos'
+            ]]));
+        } else {
+            $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        }
+
+        $this->traverser = $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new RootNamespaceNormalizer());
+
+        $this->locator = $locator;
+    }
+
+    /**
+     * Limits number of files, that can be cached at any given moment
+     *
+     * @param integer $newLimit New limit
+     *
+     * @return void
+     */
+    public function setMaximumCachedFiles($newLimit)
+    {
+        $this->maximumCachedFiles = $newLimit;
+        if (count($this->parsedFiles) > $newLimit) {
+            $this->parsedFiles = array_slice($this->parsedFiles, 0, $newLimit);
+        }
+    }
+
+    /**
+     * Locates a file name for class
+     *
+     * @param string $fullClassName Full name of the class
+     *
+     * @return string
+     */
+    public function locateClassFile($fullClassName)
+    {
+        if (class_exists($fullClassName, false)
+            || interface_exists($fullClassName, false)
+            || trait_exists($fullClassName, false)
+        ) {
+            $refClass      = new \ReflectionClass($fullClassName);
+            $classFileName = $refClass->getFileName();
+        } else {
+            $classFileName = $this->locator->locateClass($fullClassName);
+        }
+
+        if (!$classFileName) {
+            throw new \InvalidArgumentException("Class $fullClassName was not found by locator");
+        }
+
+        return $classFileName;
+    }
+
+    /**
+     * Tries to parse a class by name using LocatorInterface
+     *
+     * @param string $fullClassName Class name to load
+     *
+     * @return ClassLike
+     */
+    public function parseClass($fullClassName)
+    {
+        $classFileName  = $this->locateClassFile($fullClassName);
+        $namespaceParts = explode('\\', $fullClassName);
+        $className      = array_pop($namespaceParts);
+        $namespaceName  = join('\\', $namespaceParts);
+
+        // we have a namespace node somewhere
+        $namespace      = $this->parseFileNamespace($classFileName, $namespaceName);
+        $namespaceNodes = $namespace->stmts;
+
+        foreach ($namespaceNodes as $namespaceLevelNode) {
+            if ($namespaceLevelNode instanceof ClassLike && $namespaceLevelNode->name == $className) {
+                $namespaceLevelNode->setAttribute('fileName', $classFileName);
+
+                return $namespaceLevelNode;
+            }
+        }
+
+        throw new \InvalidArgumentException("Class $fullClassName was not found in the $classFileName");
+    }
+
+    /**
+     * Parses class method
+     *
+     * @param string $fullClassName Name of the class
+     * @param string $methodName Name of the method
+     *
+     * @return ClassMethod
+     */
+    public function parseClassMethod($fullClassName, $methodName)
+    {
+        $class      = $this->parseClass($fullClassName);
+        $classNodes = $class->stmts;
+
+        foreach ($classNodes as $classLevelNode) {
+            if ($classLevelNode instanceof ClassMethod && $classLevelNode->name == $methodName) {
+                return $classLevelNode;
+            }
+        }
+
+        throw new \InvalidArgumentException("Method $methodName was not found in the $fullClassName");
+    }
+
+    /**
+     * Parses class property
+     *
+     * @param string $fullClassName Name of the class
+     * @param string $propertyName Name of the property
+     *
+     * @return array Pair of [Property and PropertyProperty] nodes
+     */
+    public function parseClassProperty($fullClassName, $propertyName)
+    {
+        $class      = $this->parseClass($fullClassName);
+        $classNodes = $class->stmts;
+
+        foreach ($classNodes as $classLevelNode) {
+            if ($classLevelNode instanceof Property) {
+                foreach ($classLevelNode->props as $classProperty) {
+                    if ($classProperty->name == $propertyName) {
+                        return [$classLevelNode, $classProperty];
+                    }
+                }
+            }
+        }
+
+        throw new \InvalidArgumentException("Property $propertyName was not found in the $fullClassName");
+    }
+
+    /**
+     * Parses a file and returns an AST for it
+     *
+     * @param string      $fileName Name of the file
+     * @param string|null $fileContent Optional content of the file
+     *
+     * @return \PhpParser\Node[]
+     */
+    public function parseFile($fileName, $fileContent = null)
+    {
+        $fileName = PathResolver::realpath($fileName);
+        if (isset($this->parsedFiles[$fileName])) {
+            return $this->parsedFiles[$fileName];
+        }
+
+        if (isset($this->maximumCachedFiles) && (count($this->parsedFiles) === $this->maximumCachedFiles)) {
+            array_shift($this->parsedFiles);
+        }
+
+        if (!isset($fileContent)) {
+            $fileContent = file_get_contents($fileName);
+        }
+        $treeNode = $this->parser->parse($fileContent);
+        $treeNode = $this->traverser->traverse($treeNode);
+
+        $this->parsedFiles[$fileName] = $treeNode;
+
+        return $treeNode;
+    }
+
+    /**
+     * Parses a file namespace and returns an AST for it
+     *
+     * @param string $fileName Name of the file
+     * @param string $namespaceName Namespace name
+     *
+     * @return Namespace_
+     * @throws ReflectionException
+     */
+    public function parseFileNamespace($fileName, $namespaceName)
+    {
+        $topLevelNodes = $this->parseFile($fileName);
+        // namespaces can be only top-level nodes, so we can scan them directly
+        foreach ($topLevelNodes as $topLevelNode) {
+            if (!$topLevelNode instanceof Namespace_) {
+                continue;
+            }
+            $topLevelNodeName = $topLevelNode->name ? $topLevelNode->name->toString() : '';
+            if (ltrim($topLevelNodeName, '\\') === trim($namespaceName, '\\')) {
+                return $topLevelNode;
+            }
+        }
+
+        throw new ReflectionException("Namespace $namespaceName was not found in the file $fileName");
+    }
+
+    /**
+     * Provides back compatibility with static ReflectionEngine
+     * @return void
+     */
+    public function initStaticEngine(&$parsedFiles, &$maximumCachedFiles, &$parser, &$traverser)
+    {
+        $parsedFiles = $this->parsedFiles;
+        $maximumCachedFiles = $this->maximumCachedFiles;
+        $parser = $this->parser;
+        $traverser = $this->traverser;
+        $this->parsedFiles = &$parsedFiles;
+        $this->maximumCachedFiles = &$maximumCachedFiles;
+        $this->parser = &$parser;
+        $this->traverser = &$traverser;
+    }
+
+}

--- a/src/ReflectionParser.php
+++ b/src/ReflectionParser.php
@@ -89,6 +89,24 @@ class ReflectionParser
     }
 
     /**
+     * Return class reflection object
+     *
+     * @param string $fullName Full name of the class
+     *
+     * @return void
+     */
+    public function getClassReflection($fullName)
+    {
+        if (class_exists($fullName, false)
+            || interface_exists($fullName, false)
+            || trait_exists($fullName, false)
+        ) {
+            return new \ReflectionClass($fullName);
+        }
+        return new ReflectionClass($fullName, null, $this);
+    }
+
+    /**
      * Locates a file name for class
      *
      * @param string $fullClassName Full name of the class

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -111,7 +111,7 @@ class ReflectionProperty extends BaseReflectionProperty
      */
     public function getDeclaringClass()
     {
-        return new ReflectionClass($this->className);
+        return $this->reflectionParser->getClassReflection($this->className);
     }
 
     /**

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -11,6 +11,7 @@
 namespace Go\ParserReflection\Traits;
 
 use Go\ParserReflection\ReflectionClass;
+use Go\ParserReflection\ReflectionParser;
 use Go\ParserReflection\ReflectionException;
 use Go\ParserReflection\ReflectionMethod;
 use Go\ParserReflection\ReflectionProperty;
@@ -93,6 +94,11 @@ trait ReflectionClassLikeTrait
      * @var array|ReflectionProperty[]
      */
     protected $properties;
+
+    /**
+     * @var ReflectionParser
+     */
+    private $reflectionParser;
 
     /**
      * Returns the string representation of the ReflectionClass object.
@@ -345,7 +351,7 @@ trait ReflectionClassLikeTrait
     public function getMethods($filter = null)
     {
         if (!isset($this->methods)) {
-            $directMethods = ReflectionMethod::collectFromClassNode($this->classLikeNode, $this);
+            $directMethods = ReflectionMethod::collectFromClassNode($this->classLikeNode, $this, $this->reflectionParser);
             $parentMethods = $this->recursiveCollect(function (array &$result, \ReflectionClass $instance, $isParent) {
                 $reflectionMethods = [];
                 foreach ($instance->getMethods() as $reflectionMethod) {
@@ -442,7 +448,7 @@ trait ReflectionClassLikeTrait
             $extendsNode = $hasExtends ? $this->classLikeNode->$extendsField : null;
             if ($extendsNode instanceof FullyQualified) {
                 $extendsName = $extendsNode->toString();
-                $parentClass = class_exists($extendsName, false) ? new parent($extendsName) : new static($extendsName);
+                $parentClass = class_exists($extendsName, false) ? new parent($extendsName) : new static($extendsName, null, $this->reflectionParser);
             }
             $this->parentClass = $parentClass;
         }
@@ -461,7 +467,7 @@ trait ReflectionClassLikeTrait
     public function getProperties($filter = null)
     {
         if (!isset($this->properties)) {
-            $directProperties = ReflectionProperty::collectFromClassNode($this->classLikeNode, $this->getName());
+            $directProperties = ReflectionProperty::collectFromClassNode($this->classLikeNode, $this->getName(), $this->reflectionParser);
             $parentProperties = $this->recursiveCollect(function (array &$result, \ReflectionClass $instance, $isParent) {
                 $reflectionProperties = [];
                 foreach ($instance->getProperties() as $reflectionProperty) {
@@ -929,7 +935,7 @@ trait ReflectionClassLikeTrait
      */
     private function collectSelfConstants()
     {
-        $expressionSolver = new NodeExpressionResolver($this);
+        $expressionSolver = new NodeExpressionResolver($this, $this->reflectionParser);
         $localConstants   = [];
 
         // constants can be only top-level nodes in the class, so we can scan them directly

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -448,7 +448,7 @@ trait ReflectionClassLikeTrait
             $extendsNode = $hasExtends ? $this->classLikeNode->$extendsField : null;
             if ($extendsNode instanceof FullyQualified) {
                 $extendsName = $extendsNode->toString();
-                $parentClass = class_exists($extendsName, false) ? new parent($extendsName) : new static($extendsName, null, $this->reflectionParser);
+                $parentClass = $this->reflectionParser->getClassReflection($extendsName);
             }
             $this->parentClass = $parentClass;
         }
@@ -578,7 +578,7 @@ trait ReflectionClassLikeTrait
     {
         if (!isset($this->traits)) {
             $traitAdaptations = [];
-            $this->traits     = ReflectionClass::collectTraitsFromClassNode($this->classLikeNode, $traitAdaptations);
+            $this->traits     = ReflectionClass::collectTraitsFromClassNode($this->classLikeNode, $traitAdaptations, $this->reflectionParser);
             $this->traitAdaptations = $traitAdaptations;
         }
 
@@ -922,7 +922,7 @@ trait ReflectionClassLikeTrait
             $collector($result, $parentClass, $isParent);
         }
 
-        $interfaces = ReflectionClass::collectInterfacesFromClassNode($this->classLikeNode);
+        $interfaces = ReflectionClass::collectInterfacesFromClassNode($this->classLikeNode, $this->reflectionParser);
         foreach ($interfaces as $interface) {
             $collector($result, $interface, $isParent);
         }

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -13,6 +13,7 @@ namespace Go\ParserReflection\Traits;
 
 use Go\ParserReflection\NodeVisitor\GeneratorDetector;
 use Go\ParserReflection\NodeVisitor\StaticVariablesCollector;
+use Go\ParserReflection\ReflectionParser;
 use Go\ParserReflection\ReflectionParameter;
 use Go\ParserReflection\ReflectionType;
 use PhpParser\Node\Expr\Closure;
@@ -45,6 +46,11 @@ trait ReflectionFunctionLikeTrait
      * @var array|ReflectionParameter[]
      */
     protected $parameters;
+
+    /**
+     * @var ReflectionParser
+     */
+    private $reflectionParser;
 
     /**
      * {@inheritDoc}
@@ -160,7 +166,8 @@ trait ReflectionFunctionLikeTrait
                     $parameterNode->name,
                     $parameterNode,
                     $parameterIndex,
-                    $this
+                    $this,
+                    $this->reflectionParser
                 );
                 $parameters[] = $reflectionParameter;
             }
@@ -221,7 +228,7 @@ trait ReflectionFunctionLikeTrait
     public function getStaticVariables()
     {
         $nodeTraverser      = new NodeTraverser(false);
-        $variablesCollector = new StaticVariablesCollector($this);
+        $variablesCollector = new StaticVariablesCollector($this, $this->reflectionParser);
         $nodeTraverser->addVisitor($variablesCollector);
 
         /* @see https://github.com/nikic/PHP-Parser/issues/235 */

--- a/src/ValueResolver/NodeExpressionResolver.php
+++ b/src/ValueResolver/NodeExpressionResolver.php
@@ -456,15 +456,7 @@ class NodeExpressionResolver
         $className  = $node->toString();
         $isFQNClass = $node instanceof Node\Name\FullyQualified;
         if ($isFQNClass) {
-            // check to see if the class is already loaded and is safe to use
-            // PHP's ReflectionClass to determine if the class is user defined
-            if (class_exists($className, false)) {
-                $refClass = new \ReflectionClass($className);
-                if (!$refClass->isUserDefined()) {
-                    return $refClass;
-                }
-            }
-            return new ReflectionClass($className);
+            return $this->reflectionParser->getClassReflection($className);
         }
 
         if ('self' === $className) {

--- a/src/ValueResolver/NodeExpressionResolver.php
+++ b/src/ValueResolver/NodeExpressionResolver.php
@@ -11,6 +11,7 @@
 namespace Go\ParserReflection\ValueResolver;
 
 use Go\ParserReflection\ReflectionClass;
+use Go\ParserReflection\ReflectionParser;
 use Go\ParserReflection\ReflectionException;
 use Go\ParserReflection\ReflectionFileNamespace;
 use PhpParser\Node;
@@ -50,6 +51,11 @@ class NodeExpressionResolver
     private $context;
 
     /**
+     * @var ReflectionParser
+     */
+    private $reflectionParser;
+
+    /**
      * Flag if expression is constant
      *
      * @var bool
@@ -68,9 +74,10 @@ class NodeExpressionResolver
      */
     private $value;
 
-    public function __construct($context)
+    public function __construct($context, ReflectionParser $reflectionParser = null)
     {
         $this->context = $context;
+        $this->reflectionParser = $reflectionParser;
     }
 
     public function getConstantName()
@@ -233,7 +240,7 @@ class NodeExpressionResolver
             if (method_exists($this->context, 'getFileName')) {
                 $fileName      = $this->context->getFileName();
                 $namespaceName = $this->resolveScalarMagicConstNamespace();
-                $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName);
+                $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName, null, $this->reflectionParser);
                 if ($fileNamespace->hasConstant($constantName)) {
                     $constantValue = $fileNamespace->getConstant($constantName);
                     $constantName  = $fileNamespace->getName() . '\\' . $constantName;
@@ -481,7 +488,7 @@ class NodeExpressionResolver
             $fileName      = $this->context->getFileName();
             $namespaceName = $this->resolveScalarMagicConstNamespace();
 
-            $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName);
+            $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName, null, $this->reflectionParser);
             return $fileNamespace->getClass($className);
         }
 


### PR DESCRIPTION
Hi @lisachenko, thanks for great library!

I created a tool that adds missing PHP 7 typehints to codebase.  It uses Parser Reflection. This tools parses a lot of files (whole project) and checks whether all method's declarations are compatible with their prototype/interfaces. 

It is important that it uses **only** virtual AST-based class reflections and never fallback to existing classes (exception is native classes). ~~So I moved every class_exists() etc. checking to centrail point `ReflectionEngine::isClassEmulated()`.~~ So I replaced static `ReflectionEngine` with injected `ReflectionParser` and moved every class_exists() etc. checking to centrail point `ReflectionParser::getClassReflection()`

PR should be compatible with older behavior.

Now I can replace this rutine with my implementation:

```php
    public function getClassReflection($name)
    {
		if ((class_exists($name, false)
				|| interface_exists($name, false)
				|| trait_exists($name, false)
			) && !(new \ReflectionClass($name))->isUserDefined() // here is a difference
		) {
			return new \ReflectionClass($name);
		}
		return new ParserReflection\ReflectionClass($name, null, $this);
    }
```

~~It is not possible to inherit from ReflectionEngine, because all classes use static ReflectionEngine. One solution is to add something like `EmulatorDeciderInterface` with method `isEmulated` and inject it the same way as locator is injected.~~

~~Other idea is to leave the decision on locator itself. When it can locate class, use this one, when it can't use native one.~~ (Solved by injected `ReflectionParser`).

What do you think?

Idea: renamed ReflectionParser -> ReflectionContext
