### PR TITLE
Change the signature of ReflectionClass::newInstance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=5.6.0",
     "nikic/php-parser": "^1.2|^2.0|^3.0"
   },
   "require-dev": {

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -857,6 +857,7 @@ trait ReflectionClassLikeTrait
     public function newInstance($arg=null, ...$args)
     {
         $args = array_slice(array_merge([$arg], $args), 0, \func_num_args());
+        $this->initializeInternalReflection();
 
         return parent::newInstance(...$args);
     }

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -843,15 +843,22 @@ trait ReflectionClassLikeTrait
      * Creates a new class instance from given arguments.
      *
      * @link http://php.net/manual/en/reflectionclass.newinstance.php
+     *
+     * Signature was hacked to support both 5.6, 7.1.x and 7.2.0 versions
+     * @see https://3v4l.org/hW9O9
+     * @see https://3v4l.org/sWT3j
+     * @see https://3v4l.org/eeVf8
+     *
+     * @param mixed $arg First argument
      * @param mixed $args Accepts a variable number of arguments which are passed to the class constructor
      *
      * @return object
      */
-    public function newInstance($args = null)
+    public function newInstance($arg=null, ...$args)
     {
-        $this->initializeInternalReflection();
+        $args = array_slice(array_merge([$arg], $args), 0, \func_num_args());
 
-        return call_user_func_array('parent::newInstance', func_get_args());
+        return parent::newInstance(...$args);
     }
 
     /**

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -854,7 +854,7 @@ trait ReflectionClassLikeTrait
      *
      * @return object
      */
-    public function newInstance($arg=null, ...$args)
+    public function newInstance($arg = null, ...$args)
     {
         $args = array_slice(array_merge([$arg], $args), 0, \func_num_args());
         $this->initializeInternalReflection();


### PR DESCRIPTION
This PR should make `newInstance()` method implementation compatible with all modern PHP versions.

See https://3v4l.org/eeVf8 for implementation detail