### PR TITLE
[WIP] Remove leading backslash for locateClassFile()

### DIFF
--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -118,7 +118,7 @@ class ReflectionEngine
             $refClass      = new \ReflectionClass($fullClassName);
             $classFileName = $refClass->getFileName();
         } else {
-            $classFileName = self::$locator->locateClass($fullClassName);
+            $classFileName = self::$locator->locateClass(ltrim($fullClassName, '\\'));
         }
 
         if (!$classFileName) {

--- a/tests/ReflectionParameterTest.php
+++ b/tests/ReflectionParameterTest.php
@@ -171,6 +171,49 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('DateTime::ATOM', $parameters[0]->getDefaultValueConstantName());
     }
 
+    /**
+     * @dataProvider paramGlobalNsClassConstProvider
+     *
+     * @param string $methodName
+     * @param string $expectedConstName
+     */
+    public function testParamGlobalNsClassConst($methodName, $expectedConstName)
+    {
+        $this->setUpFile(__DIR__ . '/Stub/FileWithGlobalNamespacesClasses.php');
+        $parsedNamespace = $this->parsedRefFile->getFileNamespace('');
+        $parsedClass     = $parsedNamespace->getClass(\AnotherGlobalNsClass::class);
+        $parsedFunction  = $parsedClass->getMethod($methodName);
+
+        $parameters = $parsedFunction->getParameters();
+        $this->assertSame($expectedConstName, $parameters[0]->getDefaultValueConstantName());
+    }
+
+    public function paramGlobalNsClassConstProvider()
+    {
+        return [
+            '\\GlobalNsClass::A' => [
+                'slashedGlobalNs',
+                'GlobalNsClass::A',
+            ],
+            'GlobalNsClass::A' => [
+                'globalNs',
+                'GlobalNsClass::A',
+            ],
+            '\\Go\\ParserReflection\\Stub\\ClassWithScalarConstants::A' => [
+                'slashedNs',
+                'Go\\ParserReflection\\Stub\\ClassWithScalarConstants::A',
+            ],
+            'Go\\ParserReflection\\Stub\\ClassWithScalarConstants::A' => [
+                'ns',
+                'Go\\ParserReflection\\Stub\\ClassWithScalarConstants::A',
+            ],
+            '(use)ClassWithScalarConstants::A' => [
+                'useNs',
+                'Go\\ParserReflection\\Stub\\ClassWithScalarConstants::A',
+            ],
+        ];
+    }
+
     public function testGetDeclaringClassMethodReturnsNull()
     {
         $parsedNamespace = $this->parsedRefFile->getFileNamespace('Go\ParserReflection\Stub');

--- a/tests/Stub/FileWithGlobalNamespacesClasses.php
+++ b/tests/Stub/FileWithGlobalNamespacesClasses.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/FileWithClasses55.php';
+
+use Go\ParserReflection\Stub\ClassWithScalarConstants;
+
+class GlobalNsClass
+{
+    const A = 10;
+}
+
+class AnotherGlobalNsClass
+{
+    public function slashedGlobalNs($param = \GlobalNsClass::A)
+    {
+    }
+    public function globalNs($param = GlobalNsClass::A)
+    {
+    }
+    public function slashedNs($param = \Go\ParserReflection\Stub\ClassWithScalarConstants::A)
+    {
+    }
+    public function ns($param = Go\ParserReflection\Stub\ClassWithScalarConstants::A)
+    {
+    }
+    public function useNs($param = ClassWithScalarConstants::A)
+    {
+    }
+}


### PR DESCRIPTION
In some cases (maybe only in the global namespace) function get class name with leading backslash ('\SomeClassName'). Neither class_exists(), nor ComposerLocator::locateClass (with classmap) can't find file with this class. This commit fix it.

Closes #80