### PR TITLE
Eliminate nonsencical forward_static_call()s

### DIFF
--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -800,7 +800,7 @@ trait ReflectionClassLikeTrait
     {
         // In runtime static properties can be changed in any time
         if ($this->isInitialized()) {
-            return forward_static_call('parent::getStaticProperties');
+            return parent::getStaticProperties();
         }
 
         $properties = [];
@@ -908,7 +908,7 @@ trait ReflectionClassLikeTrait
     {
         $this->initializeInternalReflection();
 
-        forward_static_call('parent::setStaticPropertyValue', $name, $value);
+        parent::setStaticPropertyValue($name, $value);
     }
 
     private function recursiveCollect(\Closure $collector)

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -53,7 +53,7 @@ trait ReflectionFunctionLikeTrait
     {
         $this->initializeInternalReflection();
 
-        return forward_static_call('parent::getClosureScopeClass');
+        return parent::getClosureScopeClass();
     }
 
     /**
@@ -63,7 +63,7 @@ trait ReflectionFunctionLikeTrait
     {
         $this->initializeInternalReflection();
 
-        return forward_static_call('parent::getClosureThis');
+        return parent::getClosureThis();
     }
 
     public function getDocComment()

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -13,6 +13,8 @@ use Go\ParserReflection\Stub\AbstractClassWithMethods;
 
 abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 {
+    const DEFAULT_STUB_FILENAME = '/Stub/FileWithClasses55.php';
+
     /**
      * @var ReflectionFileNamespace
      */
@@ -109,6 +111,6 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->setUpFile(__DIR__ . '/Stub/FileWithClasses55.php');
+        $this->setUpFile(__DIR__ . self::DEFAULT_STUB_FILENAME);
     }
 }


### PR DESCRIPTION
This is an offshoot of #82. This PR eliminates the `forward_static_call()` calls that should not exist in non-static methods. I expanded the test for `setStaticPropertyValue()` and `getStaticPropertyValue()` to try and produce a bad behavior, and was unable to, so the original code **does** seem to work. The problem is that calling `forward_static_call()` from a non-static method doesn't make any sense. My test confirms, at least for the `setStaticPropertyValue()` and `getStaticPropertyValue()` methods, that both the old and new code **works**.

I did not add any tests for `getClosureThis()` and `getClosureScopeClass()`, as I don't think the current implementation can work with closures since `PhpParser\Node\Expr\Closure` doesn't have a `getName()` method, and should fail when either are called on a closure.

@lisachenko,  I mentioned that I found the original commits that added these 4 calls:
* Origin of `ReflectionFunctionLikeTrait` `forward_static_call()`s in methods `getClosureThis()` and `getClosureScopeClass()` commit https://github.com/goaop/parser-reflection/commit/240d5b55ee7b0203a936e28760fb66e9cb7a0ace
* Origin of `ReflectionClassLikeTrait` `forward_static_call()`s in methods `setStaticPropertyValue()`and `getStaticPropertyValue()` commit https://github.com/goaop/parser-reflection/commit/9503a1928796b980bd18c34405da9f4851e1cbc1

Do you have any recollection of why these were added? Was there a specific reason the code was written this way? Am I missing some reason these calls would be apropriate? I welcome your insight.

Thank you.