### PR TITLE
Fix problems with leading '\' in FQCNs

### DIFF
--- a/src/Locator/CallableLocator.php
+++ b/src/Locator/CallableLocator.php
@@ -36,6 +36,6 @@ class CallableLocator implements LocatorInterface
      */
     public function locateClass($className)
     {
-        return call_user_func($this->callable, $className);
+        return call_user_func($this->callable, ltrim($className, '\\'));
     }
 }

--- a/src/Locator/ComposerLocator.php
+++ b/src/Locator/ComposerLocator.php
@@ -51,7 +51,7 @@ class ComposerLocator implements LocatorInterface
      */
     public function locateClass($className)
     {
-        $filePath = $this->loader->findFile($className);
+        $filePath = $this->loader->findFile(ltrim($className, '\\'));
         if (!empty($filePath)) {
             $filePath = PathResolver::realpath($filePath);
         }

--- a/src/LocatorInterface.php
+++ b/src/LocatorInterface.php
@@ -19,7 +19,7 @@ interface LocatorInterface
     /**
      * Returns a path to the file for given class name
      *
-     * @param string $className Name of the class
+     * @param string $className Name of the class (with or without leading '\' FQCN)
      *
      * @return string|false Path to the file with given class or false if not found
      */

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -33,7 +33,7 @@ class ReflectionClass extends InternalReflectionClass
      */
     public function __construct($argument, ClassLike $classLikeNode = null)
     {
-        $fullClassName       = is_object($argument) ? get_class($argument) : $argument;
+        $fullClassName       = is_object($argument) ? get_class($argument) : ltrim($argument, '\\');
         $namespaceParts      = explode('\\', $fullClassName);
         $this->className     = array_pop($namespaceParts);
         // Let's unset original read-only property to have a control over it via __get

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -52,7 +52,7 @@ class ReflectionMethod extends BaseReflectionMethod
         ReflectionClass $declaringClass = null
     ) {
         //for some reason, ReflectionMethod->getNamespaceName in php always returns '', so we shouldn't use it too
-        $this->className        = $className;
+        $this->className        = ltrim($className, '\\');
         $this->declaringClass   = $declaringClass;
         $this->functionLikeNode = $classMethodNode ?: ReflectionEngine::parseClassMethod($className, $methodName);
 

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -60,7 +60,7 @@ class ReflectionProperty extends BaseReflectionProperty
         Property $propertyType = null,
         PropertyProperty $propertyNode = null
     ) {
-        $this->className    = $className;
+        $this->className = ltrim($className, '\\');
         if (!$propertyType || !$propertyNode) {
             list ($propertyType, $propertyNode) = ReflectionEngine::parseClassProperty($className, $propertyName);
         }

--- a/tests/Locator/CallableLocatorTest.php
+++ b/tests/Locator/CallableLocatorTest.php
@@ -6,11 +6,12 @@ class CallableLocatorTest extends \PHPUnit_Framework_TestCase
     public function testLocateClass()
     {
         $callable = function ($class) {
-            return $class . '.php';
+            return ltrim($class, '\\') . '.php';
         };
 
         $locator = new CallableLocator($callable);
 
         $this->assertSame('class.php', $locator->locateClass('class'));
+        $this->assertSame('class.php', $locator->locateClass('\class'));
     }
 }

--- a/tests/Locator/ComposerLocatorTest.php
+++ b/tests/Locator/ComposerLocatorTest.php
@@ -13,5 +13,9 @@ class ComposerLocatorTest extends \PHPUnit_Framework_TestCase
             $reflectionClass->getFileName(),
             $locator->locateClass(ReflectionClass::class)
         );
+        $this->assertSame(
+            $reflectionClass->getFileName(),
+            $locator->locateClass('\\' . ReflectionClass::class)
+        );
     }
 }

--- a/tests/Stub/Issue44/Locator.php
+++ b/tests/Stub/Issue44/Locator.php
@@ -11,7 +11,7 @@ class Locator implements LocatorInterface
      */
     public function locateClass($className)
     {
-        if ($className === '\\Stub\\Issue44\\ClassWithNamespace') {
+        if ($className === ClassWithNamespace::class) {
             return __DIR__ . '/ClassWithNamespace.php';
         }
 

--- a/tests/Stub/Issue44/Locator.php
+++ b/tests/Stub/Issue44/Locator.php
@@ -11,7 +11,7 @@ class Locator implements LocatorInterface
      */
     public function locateClass($className)
     {
-        if ($className === ClassWithNamespace::class) {
+        if (ltrim($className, '\\') === ClassWithNamespace::class) {
             return __DIR__ . '/ClassWithNamespace.php';
         }
 


### PR DESCRIPTION
I found a inconsistent behavior about classname in native \Reflection* and \Go\ParserReflection\Reflection* 

Is it unexpected behavior? The native Reflection* constructors drop the leading slash in the string class name parameter. I made changes in constructors to consist behavior and pass thees tests.  It's ready to push. Also it closes #80.
