### PR TITLE
getNamespaceAliases() behavior changed in 2.0

### DIFF
--- a/src/ReflectionFileNamespace.php
+++ b/src/ReflectionFileNamespace.php
@@ -454,7 +454,7 @@ class ReflectionFileNamespace
                 $useAliases = $namespaceLevelNode->uses;
                 if (!empty($useAliases)) {
                     foreach ($useAliases as $useNode) {
-                        $namespaceAliases[$useNode->name->toString()] = $useNode->alias;
+                        $namespaceAliases[$useNode->name->toString()] = (string) $useNode->getAlias();
                     }
                 }
             }

--- a/tests/ReflectionFileNamespaceTest.php
+++ b/tests/ReflectionFileNamespaceTest.php
@@ -162,9 +162,10 @@ class ReflectionFileNamespaceTest extends \PHPUnit_Framework_TestCase
     public function testGetNamespaceAliases()
     {
         $expectedAliases = [
-            'ReflectionClass'     => 'UnusedReflectionClass',
-            'PhpParser\Node'      => 'UnusedNode',
-            'PhpParser\Node\Expr' => 'UnusedNodeExpr'
+            'SomeClass\WithoutAlias' => 'WithoutAlias',
+            'ReflectionClass'        => 'UnusedReflectionClass',
+            'PhpParser\Node'         => 'UnusedNode',
+            'PhpParser\Node\Expr'    => 'UnusedNodeExpr'
         ];
 
         $realAliases = $this->parsedRefFileNamespace->getNamespaceAliases();

--- a/tests/Stub/FileWithNamespaces.php
+++ b/tests/Stub/FileWithNamespaces.php
@@ -7,6 +7,7 @@ namespace Go\ParserReflection\Stub
 {
     const START_MARKER = __LINE__; // Do not move it anywhere
 
+    use SomeClassWithoutAlias;
     use ReflectionClass as UnusedReflectionClass;
     use PhpParser\Node as UnusedNode, PhpParser\Node\Expr as UnusedNodeExpr;
 

--- a/tests/Stub/FileWithNamespaces.php
+++ b/tests/Stub/FileWithNamespaces.php
@@ -7,7 +7,7 @@ namespace Go\ParserReflection\Stub
 {
     const START_MARKER = __LINE__; // Do not move it anywhere
 
-    use SomeClassWithoutAlias;
+    use SomeClass\WithoutAlias;
     use ReflectionClass as UnusedReflectionClass;
     use PhpParser\Node as UnusedNode, PhpParser\Node\Expr as UnusedNodeExpr;
 


### PR DESCRIPTION
## What to do?
```php
// file to parse
use SomeClass\WithoutAlias;
use AnotherClass\WithAlias as SomeSuperClass;


// parse the file somewhere else
$result = $reflectionNamespace->getNamespaceAliases();

```


## Expected result
```
$result = [
    'SomeClass\WithoutAlias' => 'WithoutAlias'
    'AnotherClass\WithAlias' => 'SomeSuperClass'
];
```

## Actual result
```
$result = [
    'SomeClass\WithoutAlias' => null
    'AnotherClass\WithAlias' => 'SomeSuperClass'
];
```

## Explanation
The result of getNamespaceAliases() was changed in version 2.0 through a change in php-parser v4.

In php-parser v3 you can find this fallback logic for "use"-statements without an "as" (so without an alias): https://github.com/nikic/PHP-Parser/blob/3.x/lib/PhpParser/Builder/Use_.php#L53

The logic was moved in v4 from the builder: https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Builder/Use_.php#L44

To the node: https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Node/Stmt/UseUse.php#L46

In the parser-reflection you only use the public property "alias" of the node and not the "getAlias" method: https://github.com/goaop/parser-reflection/blob/master/src/ReflectionFileNamespace.php#L457

This pull request fixes this behavior and will result in the same result like in version 1.

I also added unit tests for this because there was none without an alias.