### PR TITLE
[Feature] Make it possible to scan for deprecated types.

### DIFF
--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -164,12 +164,12 @@ class ReflectionEngine
      *
      * @return null|ClassLike
      */
-    protected static function findClassLikeNodeByClassName($nodes, $className) {
+    protected static function findClassLikeNodeByClassName($nodes, $className)
+    {
         foreach ($nodes as $node) {
             if ($node instanceof ClassLike && $node->name == $className) {
                 return $node;
-            } elseif (
-                $node instanceof Node\Stmt\If_
+            } elseif ($node instanceof Node\Stmt\If_
                 && $node->cond instanceof Node\Expr\ConstFetch
                 && isset($node->cond->name->parts[0])
                 && $node->cond->name->parts[0] === 'false'


### PR DESCRIPTION
According to https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf.

Should resolve #99 

I could not find any tests for `\Go\ParserReflection\ReflectionEngine::parseClass()`, so I did not add new ones for now. We could figure some out though.