### PR TITLE
Temporary restrict installation of broken php-parser versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require": {
     "php": ">=7.1",
-    "nikic/php-parser": "^4.0"
+    "nikic/php-parser": "^4.0 <4.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
New patch release should be prepared quickly to have proper `endTokenPos` reporting.