### PR TITLE
Improve PHPUnit namespace and some stuffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "nikic/php-parser": "^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "^7.0"
   },
   "extra": {
     "branch-alias": {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -9,9 +9,10 @@
  */
 namespace Go\ParserReflection;
 
+use PHPUnit\Framework\TestCase;
 use Go\ParserReflection\Stub\AbstractClassWithMethods;
 
-abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends TestCase
 {
     const DEFAULT_STUB_FILENAME = '/Stub/FileWithClasses55.php';
 
@@ -109,7 +110,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         include_once $fileName;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->setUpFile(__DIR__ . self::DEFAULT_STUB_FILENAME);
     }

--- a/tests/Locator/CallableLocatorTest.php
+++ b/tests/Locator/CallableLocatorTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Go\ParserReflection\Locator;
 
-class CallableLocatorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CallableLocatorTest extends TestCase
 {
     public function testLocateClass()
     {

--- a/tests/Locator/ComposerLocatorTest.php
+++ b/tests/Locator/ComposerLocatorTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Go\ParserReflection\Locator;
 
+use PHPUnit\Framework\TestCase;
 use Go\ParserReflection\ReflectionClass;
 
-class ComposerLocatorTest extends \PHPUnit_Framework_TestCase
+class ComposerLocatorTest extends TestCase
 {
     public function testLocateClass()
     {

--- a/tests/ReflectionClassConstantTest.php
+++ b/tests/ReflectionClassConstantTest.php
@@ -3,19 +3,20 @@ declare(strict_types=1);
 
 namespace Go\ParserReflection;
 
+use PHPUnit\Framework\TestCase;
 use Go\ParserReflection\Stub\Foo;
 use Go\ParserReflection\Stub\SubFoo;
 use TestParametersForRootNsClass;
 use Go\ParserReflection\Stub\ClassWithPhp71Features;
 
-class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
+class ReflectionClassConstantTest extends TestCase
 {
     /**
      * @var ReflectionFile
      */
     protected $parsedRefFile;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->setUpFile(__DIR__ . '/Stub/FileWithClasses71.php');
     }
@@ -93,7 +94,7 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
         }
 
         if ($allMissedMethods) {
-            $this->markTestIncomplete('Methods ' . implode($allMissedMethods, ', ') . ' are not implemented');
+            $this->markTestIncomplete('Methods ' . implode(', ', $allMissedMethods) . ' are not implemented');
         }
     }
 

--- a/tests/ReflectionFileNamespaceTest.php
+++ b/tests/ReflectionFileNamespaceTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Go\ParserReflection;
 
+use PHPUnit\Framework\TestCase;
 use Go\ParserReflection\Stub\TestNamespaceClassFoo;
 
-class ReflectionFileNamespaceTest extends \PHPUnit_Framework_TestCase
+class ReflectionFileNamespaceTest extends TestCase
 {
     const STUB_FILE = '/Stub/FileWithNamespaces.php';
     const STUB_GLOBAL_FILE = '/Stub/FileWithGlobalNamespace.php';
@@ -13,7 +14,7 @@ class ReflectionFileNamespaceTest extends \PHPUnit_Framework_TestCase
      */
     protected $parsedRefFileNamespace;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $fileName = stream_resolve_include_path(__DIR__ . self::STUB_FILE);
         $fileNode = ReflectionEngine::parseFile($fileName);

--- a/tests/ReflectionFileTest.php
+++ b/tests/ReflectionFileTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Go\ParserReflection;
 
+use PHPUnit\Framework\TestCase;
 use Stub\Issue44\Locator;
 
-class ReflectionFileTest extends \PHPUnit_Framework_TestCase
+class ReflectionFileTest extends TestCase
 {
     const STUB_FILE        = '/Stub/FileWithNamespaces.php';
     const STUB_GLOBAL_FILE = '/Stub/FileWithGlobalNamespace.php';
@@ -13,7 +14,7 @@ class ReflectionFileTest extends \PHPUnit_Framework_TestCase
      */
     protected $parsedRefFile;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $fileName       = stream_resolve_include_path(__DIR__ . self::STUB_FILE);
         $reflectionFile = new ReflectionFile($fileName);

--- a/tests/ReflectionFunctionTest.php
+++ b/tests/ReflectionFunctionTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Go\ParserReflection;
 
-class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ReflectionFunctionTest extends TestCase
 {
     const STUB_FILE55 = '/Stub/FileWithFunctions55.php';
     const STUB_FILE70 = '/Stub/FileWithFunctions70.php';
@@ -11,7 +13,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
      */
     protected $parsedRefFile;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $fileName = stream_resolve_include_path(__DIR__ . self::STUB_FILE55);
 

--- a/tests/ReflectionParameterTest.php
+++ b/tests/ReflectionParameterTest.php
@@ -1,18 +1,19 @@
 <?php
 namespace Go\ParserReflection;
 
+use PHPUnit\Framework\TestCase;
 use Go\ParserReflection\Stub\Foo;
 use Go\ParserReflection\Stub\SubFoo;
 use TestParametersForRootNsClass;
 
-class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
+class ReflectionParameterTest extends TestCase
 {
     /**
      * @var ReflectionFile
      */
     protected $parsedRefFile;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->setUpFile(__DIR__ . '/Stub/FileWithParameters55.php');
     }

--- a/tests/ReflectionTypeTest.php
+++ b/tests/ReflectionTypeTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Go\ParserReflection;
 
-class ReflectionTypeTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ReflectionTypeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (PHP_VERSION_ID >= 70000) {
             include_once (__DIR__ . '/Stub/FileWithClasses70.php');

--- a/tests/ValueResolver/NodeExpressionResolverTest.php
+++ b/tests/ValueResolver/NodeExpressionResolverTest.php
@@ -1,17 +1,19 @@
 <?php
 namespace Go\ParserReflection\ValueResolver;
 
+
+use PHPUnit\Framework\TestCase;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 
-class NodeExpressionResolverTest extends \PHPUnit_Framework_TestCase
+class NodeExpressionResolverTest extends TestCase
 {
     /**
      * @var null|Parser
      */
     protected $parser = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
     }


### PR DESCRIPTION
# Changed log

- Using the `PHPUnit` `^7.0` version to support the `php-7.1+` versions.
- Using the `PHPUnit\Framework\TestCase` to support `PHPUnit ^7` version.
- The PHPUnit `^7` version about fixture is `protected function setUp(): void`.
- Since `php-7.4` version is released, the `implode` function arguments are `implode($glue, $pieces)` . It should be swapped.

The deprecated message is follows:
`PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters`

The more details about `implode` is available on [official PHP doc](https://www.php.net/manual/en/function.implode.php#refsect1-function.implode-changelog).