### PR TITLE
Unary minus value expr isn't resolved correctly in NodeExpressionResolver

### DIFF
--- a/src/ValueResolver/NodeExpressionResolver.php
+++ b/src/ValueResolver/NodeExpressionResolver.php
@@ -142,6 +142,12 @@ class NodeExpressionResolver
         return $node->value;
     }
 
+    protected function resolveExprUnaryMinus(Expr\UnaryMinus $node)
+    {
+        $value = $this->resolve($node->expr);
+        return -1 * $value;
+    }
+
     protected function resolveScalarString(String_ $node): string
     {
         return $node->value;

--- a/src/ValueResolver/NodeExpressionResolver.php
+++ b/src/ValueResolver/NodeExpressionResolver.php
@@ -148,6 +148,11 @@ class NodeExpressionResolver
         return -1 * $value;
     }
 
+    protected function resolveExprUnaryPlus(Expr\UnaryMinus $node)
+    {
+        return $this->resolve($node->expr);
+    }
+
     protected function resolveScalarString(String_ $node): string
     {
         return $node->value;

--- a/tests/ReflectionMethodTest.php
+++ b/tests/ReflectionMethodTest.php
@@ -20,15 +20,15 @@ class ReflectionMethodTest extends AbstractTestCase
     public function testInvokeMethod()
     {
         $refMethod = $this->parsedRefClass->getMethod('funcWithReturnArgs');
-        $retValue  = $refMethod->invoke(null, 1, 2, 3);
-        $this->assertEquals([1, 2, 3], $retValue);
+        $retValue  = $refMethod->invoke(null, 1, 2, 3, -100, -10.5);
+        $this->assertEquals([1, 2, 3, -100, -10.5], $retValue);
     }
 
     public function testInvokeArgsMethod()
     {
         $refMethod = $this->parsedRefClass->getMethod('funcWithReturnArgs');
-        $retValue  = $refMethod->invokeArgs(null, [1, 2, 3]);
-        $this->assertEquals([1, 2, 3], $retValue);
+        $retValue  = $refMethod->invokeArgs(null, [1, 2, 3, -100, -10.5]);
+        $this->assertEquals([1, 2, 3, -100, -10.5], $retValue);
     }
 
     public function testDebugInfoMethod()

--- a/tests/Stub/FileWithClasses55.php
+++ b/tests/Stub/FileWithClasses55.php
@@ -9,6 +9,7 @@ abstract class ImplicitAbstractClass
     private $a = 'foo';
     protected $b = 'bar';
     public $c = 'baz';
+    public $d = -1;
 
     abstract function test();
 }
@@ -39,6 +40,7 @@ class BaseClass
 abstract class AbstractClassWithMethods extends BaseClass
 {
     const TEST = 5;
+    const TEST2 = -5;
 
     public function __construct(){}
     public function __destruct(){}
@@ -56,14 +58,14 @@ abstract class AbstractClassWithMethods extends BaseClass
      */
     public static function funcWithDocAndBody()
     {
-        static $a =5, $test = '1234';
+        static $a =5, $b = -5, $test = '1234';
 
         return 'hello';
     }
 
-    public static function funcWithReturnArgs($a, $b = 100, $c = 10.0)
+    public static function funcWithReturnArgs($a, $b = 100, $c = 10.0, $d = -100, $e = -10.5)
     {
-        return [$a, $b, $c];
+        return [$a, $b, $c, $d, $e];
     }
 
     public static function prototypeMethod()
@@ -102,6 +104,7 @@ class ClassWithProperties
     private $privateProperty = 123;
     protected $protectedProperty = 'a';
     public $publicProperty = 42.0;
+    private $privateProperty2 = -123;
 
     /**
      * Some message to test docBlock
@@ -228,6 +231,8 @@ class ClassWithScalarConstants
     const C = 'foo';
     const D = false;
     const E = null;
+    const F = -5;
+    const G = -6.123;
 }
 
 class ClassWithMagicConstants

--- a/tests/Stub/FileWithClasses71.php
+++ b/tests/Stub/FileWithClasses71.php
@@ -58,6 +58,7 @@ class ClassWithPhp71Features
     private const PRIVATE_CONST = 4;
 
     public const CALCULATED_CONST = 1 + 1;
+    public const CALCULATED_CONST2 = -1 + -1;
 
     public function returnsVoid() : void {}
     public function acceptsIterable(iterable $iterable) : iterable {}


### PR DESCRIPTION
Given code:
```php
class Test
{
    const A = -5;

    protected $a = -5;

    public function test($a = -5)
    {}
}
```

All of these value cannot be parsed correctly in the current version (v3.0.1).

The values of all elements are parsed as "NULL". 

The problem can be found in the [NodeExpressionResolver](https://github.com/goaop/parser-reflection/blob/master/src/ValueResolver/NodeExpressionResolver.php). Negativ values are parsed as [UnaryMinus](https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Node/Expr/UnaryMinus.php) with an expression inside. But at the moment there is no "resolveExprUnaryMinus" method and so these nodes are completely ignored. 

The same counts for an unary plus. But in most cases you would never write an unary plus before positive numbers (at least I never did it or have seen it).
