### PR TITLE
[Step 3 Upgrade] Enable skipped test: ReflectionClassTest::testGetModifiers()

### DIFF
--- a/tests/ReflectionClassTest.php
+++ b/tests/ReflectionClassTest.php
@@ -32,8 +32,7 @@ class ReflectionClassTest extends AbstractTestCase
     {
         $mask =
             \ReflectionClass::IS_EXPLICIT_ABSTRACT
-            + \ReflectionClass::IS_FINAL
-            + \ReflectionClass::IS_IMPLICIT_ABSTRACT;
+            + \ReflectionClass::IS_FINAL;
 
         $this->setUpFile($fileName);
         $parsedClasses = $this->parsedRefFileNamespace->getClasses();

--- a/tests/ReflectionClassTest.php
+++ b/tests/ReflectionClassTest.php
@@ -30,9 +30,6 @@ class ReflectionClassTest extends AbstractTestCase
      */
     public function testGetModifiers($fileName)
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->markTestSkipped('TODO: Fix mapping and logic of modifiers');
-        }
         $mask =
             \ReflectionClass::IS_EXPLICIT_ABSTRACT
             + \ReflectionClass::IS_FINAL


### PR DESCRIPTION
@lisachenko here the 3rd step 👍 , enable skipped test of `ReflectionClassTest::testGetModifiers()`