### PR TITLE
Feature/claude phpstan level10 php85

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,36 @@
+name: "PHPStan analysis"
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "PHPStan analysis - PHP8.4"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          ini-values: memory_limit=-1
+          tools: composer:v2
+      - name: "Cache dependencies"
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: "php-8.4"
+          restore-keys: "php-8.4"
+      - name: "Install dependencies"
+        run: "composer install --no-interaction --no-progress"
+      - name: "Static analysis"
+        run: "vendor/bin/phpstan analyze --memory-limit=1G"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,9 +15,8 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
+          - "8.5"
           - "8.4"
-          - "8.3"
-          - "8.2"
         operating-system:
           - "ubuntu-latest"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,6 @@ vendor/bin/phpunit --filter testMethodName
 
 # Static analysis (~5 seconds, 18 known existing errors are normal)
 vendor/bin/phpstan analyse src --no-progress
-
-# Code quality check (dry-run only — don't auto-apply)
-vendor/bin/rector --dry-run
 ```
 
 > **Note on `composer install` locally**: due to GitHub API rate limits, use `--prefer-source` and set a long timeout: `composer config --global process-timeout 2000`. In CI, standard `composer install` works fine with GitHub tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Parser Reflection is a **deprecated** PHP library (deprecated in favor of [BetterReflection](https://github.com/Roave/BetterReflection)) that extends PHP's internal reflection classes using nikic/PHP-Parser for static analysis. It reflects PHP code without loading classes into memory by parsing source files into an AST.
+
+Requires PHP >=8.2. Namespace: `Go\ParserReflection\`.
+
+## Commands
+
+```bash
+# Install dependencies (slow locally — see note below)
+composer install --prefer-source --no-interaction
+
+# Run tests (~6 seconds, ~10,500 tests)
+vendor/bin/phpunit
+
+# Run a single test file
+vendor/bin/phpunit tests/ReflectionClassTest.php
+
+# Run a specific test method
+vendor/bin/phpunit --filter testMethodName
+
+# Static analysis (~5 seconds, 18 known existing errors are normal)
+vendor/bin/phpstan analyse src --no-progress
+
+# Code quality check (dry-run only — don't auto-apply)
+vendor/bin/rector --dry-run
+```
+
+> **Note on `composer install` locally**: due to GitHub API rate limits, use `--prefer-source` and set a long timeout: `composer config --global process-timeout 2000`. In CI, standard `composer install` works fine with GitHub tokens.
+
+## Architecture
+
+### Request flow
+
+When you call `new ReflectionClass('SomeClass')`:
+1. `ReflectionClass` asks `ReflectionEngine` for the class's AST node
+2. `ReflectionEngine` uses the registered `LocatorInterface` to find the file
+3. The file is parsed by PHP-Parser into an AST
+4. Two node visitors run: `NameResolver` (resolves FQCNs) and `RootNamespaceNormalizer` (normalizes global namespace)
+5. The resulting `ClassLike` AST node is stored in `ReflectionEngine::$parsedFiles` (in-memory LRU cache)
+6. The node is wrapped in the appropriate reflection class
+
+### Key components
+
+- **`ReflectionEngine`** (`src/ReflectionEngine.php`) — static class; central hub. Owns the PHP-Parser instance, AST cache, and locator. Entry points: `parseFile()`, `parseClass()`, `parseClassMethod()`, etc.
+- **`LocatorInterface`** / **`ComposerLocator`** — pluggable class file finder. `ComposerLocator` delegates to Composer's classmap/autoloader. `bootstrap.php` auto-registers `ComposerLocator` on load.
+- **Reflection classes** (`src/Reflection*.php`) — each extends its PHP internal counterpart (e.g. `ReflectionClass extends \ReflectionClass`) and holds an AST node. Methods that require a live object (e.g. `invoke()`) trigger actual class loading and fall back to native reflection.
+- **Traits** (`src/Traits/`) — shared logic extracted to avoid duplication:
+  - `ReflectionClassLikeTrait` — used by `ReflectionClass`; implements most class inspection methods against the AST
+  - `ReflectionFunctionLikeTrait` — shared by `ReflectionMethod` and `ReflectionFunction`
+  - `InitializationTrait` — lazy initialization of AST node from engine
+  - `InternalPropertiesEmulationTrait` — makes `var_dump`/serialization look like native reflection
+  - `AttributeResolverTrait` — resolves PHP 8 attributes from AST nodes
+- **Resolvers** (`src/Resolver/`) — `NodeExpressionResolver` evaluates constant expressions in the AST (used for default values, constants). `TypeExpressionResolver` resolves type AST nodes into reflection type objects.
+- **`ReflectionFile` / `ReflectionFileNamespace`** — library-specific (not in native PHP reflection). Allow reflecting arbitrary PHP files and iterating their namespaces, classes, functions without knowing class names in advance.
+
+### Test structure
+
+Tests in `tests/` mirror the reflection class names (e.g. `ReflectionClassTest.php`). PHP version-specific stub files in `tests/Stub/` (e.g. `FileWithClasses84.php`) contain the PHP code being reflected. Tests extend `AbstractTestCase` which sets up the `ReflectionEngine` with a `ComposerLocator`.
+
+### CI
+
+GitHub Actions (`.github/workflows/phpunit.yml`) runs PHPUnit on PHP 8.2, 8.3, 8.4 with both lowest and highest dependency versions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Parser Reflection is a **deprecated** PHP library (deprecated in favor of [BetterReflection](https://github.com/Roave/BetterReflection)) that extends PHP's internal reflection classes using nikic/PHP-Parser for static analysis. It reflects PHP code without loading classes into memory by parsing source files into an AST.
 
-Requires PHP >=8.2. Namespace: `Go\ParserReflection\`.
+Requires PHP >=8.4. Namespace: `Go\ParserReflection\`.
 
 ## Commands
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.4",
     "nikic/php-parser": "^5.4"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^11.0.7",
+    "phpstan/phpstan": "^2.0",
     "tracy/tracy": "^2.10",
-    "rector/rector": "^1.0",
-    "rector/rector-php-parser": "^0.14.0"
+    "rector/rector": "^2.0"
   },
   "extra": {
     "branch-alias": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+  level: 5
+  paths:
+    - src

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 5
+  level: 10
   paths:
     - src
   treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,12 @@ parameters:
       path: src/ReflectionFunction.php
     - identifier: unset.possiblyHookedProperty
       path: src/ReflectionMethod.php
+    # Class names from the AST are semantically class-strings by construction (they come from
+    # parsed PHP class declarations), but PHPStan cannot verify this without autoloading, which
+    # would violate the library's contract of reflecting code without loading classes.
+    - identifier: return.type
+      path: src/Traits/ReflectionClassLikeTrait.php
+      message: '#resolveAsClassString#'
+    - identifier: return.type
+      path: src/Traits/AttributeResolverTrait.php
+      message: '#resolveAttributeClassName#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,6 @@ parameters:
   level: 10
   paths:
     - src
-  treatPhpDocTypesAsCertain: false
   ignoreErrors:
     # Both classes are final, so "might have hooks in a subclass" is a false positive
     - identifier: unset.possiblyHookedProperty

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,10 @@ parameters:
   level: 5
   paths:
     - src
+  treatPhpDocTypesAsCertain: false
+  ignoreErrors:
+    # Both classes are final, so "might have hooks in a subclass" is a false positive
+    - identifier: unset.possiblyHookedProperty
+      path: src/ReflectionFunction.php
+    - identifier: unset.possiblyHookedProperty
+      path: src/ReflectionMethod.php

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -29,7 +29,7 @@ class PathResolver
      * @param string|array<int, string> $somePath             Path without normalization or array of paths
      * @param bool                      $shouldCheckExistence Flag for checking existence of resolved filename
      *
-     * @return array<int, string>|bool|string
+     * @return ($somePath is array ? array<int, string|false> : string|false)
      */
     public static function realpath($somePath, $shouldCheckExistence = false)
     {

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -50,7 +50,8 @@ class PathResolver
             return $fastPath;
         }
 
-        $isRelative = !$pathScheme && $path !== null && ($path[0] !== '/') && ($path[1] !== ':');
+        $isWindowsAbsolutePath = $path !== null && strlen($path) > 1 && preg_match('/^[A-Za-z]:/', $path) === 1;
+        $isRelative = !$pathScheme && $path !== null && !str_starts_with($path, '/') && !$isWindowsAbsolutePath;
         if ($isRelative) {
             $path = getcwd() . DIRECTORY_SEPARATOR . $path;
         }

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -50,13 +50,13 @@ class PathResolver
             return $fastPath;
         }
 
-        $isRelative = !$pathScheme && ($path[0] !== '/') && ($path[1] !== ':');
+        $isRelative = !$pathScheme && $path !== null && ($path[0] !== '/') && ($path[1] !== ':');
         if ($isRelative) {
             $path = getcwd() . DIRECTORY_SEPARATOR . $path;
         }
 
         // resolve path parts (single dot, double dot and double delimiters)
-        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path ?? '');
         if (strpos($path, '.') !== false) {
             $parts     = explode(DIRECTORY_SEPARATOR, $path);
             $absolutes = [];

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -26,10 +26,10 @@ class PathResolver
     /**
      * Custom replacement for realpath() and stream_resolve_include_path()
      *
-     * @param string|array $somePath             Path without normalization or array of paths
-     * @param bool         $shouldCheckExistence Flag for checking existence of resolved filename
+     * @param string|array<int, string> $somePath             Path without normalization or array of paths
+     * @param bool                      $shouldCheckExistence Flag for checking existence of resolved filename
      *
-     * @return array|bool|string
+     * @return array<int, string>|bool|string
      */
     public static function realpath($somePath, $shouldCheckExistence = false)
     {

--- a/src/Locator/CallableLocator.php
+++ b/src/Locator/CallableLocator.php
@@ -37,6 +37,8 @@ class CallableLocator implements LocatorInterface
      */
     public function locateClass(string $className): false|string
     {
-        return call_user_func($this->callable, ltrim($className, '\\'));
+        $result = call_user_func($this->callable, ltrim($className, '\\'));
+
+        return is_string($result) ? $result : false;
     }
 }

--- a/src/Locator/CallableLocator.php
+++ b/src/Locator/CallableLocator.php
@@ -12,22 +12,18 @@ declare(strict_types=1);
 
 namespace Go\ParserReflection\Locator;
 
+use Closure;
 use Go\ParserReflection\LocatorInterface;
 
 /**
  * Locator, that can find a file for the given class name by asking composer
  * @see \Go\ParserReflection\Locator\CallableLocatorTest
  */
-class CallableLocator implements LocatorInterface
+final readonly class CallableLocator implements LocatorInterface
 {
-    /**
-     * @var callable
-     */
-    private $callable;
 
-    public function __construct(callable $callable)
+    public function __construct(private Closure $callable)
     {
-        $this->callable = $callable;
     }
 
     /**
@@ -37,7 +33,7 @@ class CallableLocator implements LocatorInterface
      */
     public function locateClass(string $className): false|string
     {
-        $result = call_user_func($this->callable, ltrim($className, '\\'));
+        $result = ($this->callable)(ltrim($className, '\\'));
 
         return is_string($result) ? $result : false;
     }

--- a/src/Locator/ComposerLocator.php
+++ b/src/Locator/ComposerLocator.php
@@ -23,10 +23,8 @@ use Go\ParserReflection\ReflectionException;
  */
 class ComposerLocator implements LocatorInterface
 {
-    /**
-     * @var ClassLoader
-     */
-    private $loader;
+
+    private ClassLoader $loader;
 
     public function __construct(?ClassLoader $composerLoader = null)
     {

--- a/src/Locator/ComposerLocator.php
+++ b/src/Locator/ComposerLocator.php
@@ -54,7 +54,8 @@ class ComposerLocator implements LocatorInterface
     {
         $filePath = $this->loader->findFile(ltrim($className, '\\'));
         if (!empty($filePath)) {
-            $filePath = PathResolver::realpath($filePath);
+            $resolvedPath = PathResolver::realpath($filePath);
+            $filePath = is_string($resolvedPath) ? $resolvedPath : false;
         }
 
         return $filePath;

--- a/src/NodeVisitor/RootNamespaceNormalizer.php
+++ b/src/NodeVisitor/RootNamespaceNormalizer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Go\ParserReflection\NodeVisitor;
 
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
@@ -45,7 +46,11 @@ class RootNamespaceNormalizer extends NodeVisitorAbstract
             }
         }
         // Wrap all statements into the namespace block
-        $globalNamespaceNode = new Namespace_(null, array_slice($nodes, $lastDeclareOffset));
+        $stmts = array_values(array_filter(
+            array_slice($nodes, $lastDeclareOffset),
+            static fn ($node) => $node instanceof Stmt
+        ));
+        $globalNamespaceNode = new Namespace_(null, $stmts);
         // Replace top-level nodes with namespaced node
         array_splice($nodes, $lastDeclareOffset, count($nodes), [$globalNamespaceNode]);
 

--- a/src/NodeVisitor/StaticVariablesCollector.php
+++ b/src/NodeVisitor/StaticVariablesCollector.php
@@ -12,6 +12,14 @@ declare(strict_types=1);
 
 namespace Go\ParserReflection\NodeVisitor;
 
+use Go\ParserReflection\ReflectionAttribute;
+use Go\ParserReflection\ReflectionClass;
+use Go\ParserReflection\ReflectionClassConstant;
+use Go\ParserReflection\ReflectionFileNamespace;
+use Go\ParserReflection\ReflectionFunction;
+use Go\ParserReflection\ReflectionMethod;
+use Go\ParserReflection\ReflectionParameter;
+use Go\ParserReflection\ReflectionProperty;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -23,8 +31,10 @@ class StaticVariablesCollector extends NodeVisitorAbstract
 {
     /**
      * Reflection context, eg. ReflectionClass, ReflectionMethod, etc
+     *
+     * @var \ReflectionClass<object>|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|\ReflectionParameter|\ReflectionAttribute<object>|\ReflectionProperty|ReflectionFileNamespace|null
      */
-    private mixed $context;
+    private \ReflectionClass|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|\ReflectionParameter|\ReflectionAttribute|\ReflectionProperty|ReflectionFileNamespace|null $context;
 
     /**
      * @var array<string, mixed>
@@ -34,9 +44,9 @@ class StaticVariablesCollector extends NodeVisitorAbstract
     /**
      * Default constructor
      *
-     * @param mixed $context Reflection context, eg. ReflectionClass, ReflectionMethod, etc
+     * @param \ReflectionClass<object>|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|\ReflectionParameter|\ReflectionAttribute<object>|\ReflectionProperty|ReflectionFileNamespace|null $context Reflection context, eg. ReflectionClass, ReflectionMethod, etc
      */
-    public function __construct(mixed $context)
+    public function __construct(\ReflectionClass|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|\ReflectionParameter|\ReflectionAttribute|\ReflectionProperty|ReflectionFileNamespace|null $context)
     {
         $this->context = $context;
     }
@@ -65,7 +75,11 @@ class StaticVariablesCollector extends NodeVisitorAbstract
 
                 if ($staticVariable->var->name instanceof Node\Expr) {
                     $expressionSolver->process($staticVariable->var->name);
-                    $name = $expressionSolver->getValue();
+                    $resolvedName = $expressionSolver->getValue();
+                    if (!is_string($resolvedName)) {
+                        continue;
+                    }
+                    $name = $resolvedName;
                 } else {
                     $name = $staticVariable->var->name;
                 }

--- a/src/NodeVisitor/StaticVariablesCollector.php
+++ b/src/NodeVisitor/StaticVariablesCollector.php
@@ -12,14 +12,7 @@ declare(strict_types=1);
 
 namespace Go\ParserReflection\NodeVisitor;
 
-use Go\ParserReflection\ReflectionAttribute;
-use Go\ParserReflection\ReflectionClass;
-use Go\ParserReflection\ReflectionClassConstant;
 use Go\ParserReflection\ReflectionFileNamespace;
-use Go\ParserReflection\ReflectionFunction;
-use Go\ParserReflection\ReflectionMethod;
-use Go\ParserReflection\ReflectionParameter;
-use Go\ParserReflection\ReflectionProperty;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -77,7 +70,7 @@ class StaticVariablesCollector extends NodeVisitorAbstract
                     $expressionSolver->process($staticVariable->var->name);
                     $resolvedName = $expressionSolver->getValue();
                     if (!is_string($resolvedName)) {
-                        continue;
+                        throw new \InvalidArgumentException("Unknown value for the key, " . gettype($resolvedName) . " has given, but string is expected");
                     }
                     $name = $resolvedName;
                 } else {

--- a/src/NodeVisitor/StaticVariablesCollector.php
+++ b/src/NodeVisitor/StaticVariablesCollector.php
@@ -26,6 +26,9 @@ class StaticVariablesCollector extends NodeVisitorAbstract
      */
     private mixed $context;
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $staticVariables = [];
 
     /**
@@ -75,6 +78,8 @@ class StaticVariablesCollector extends NodeVisitorAbstract
 
     /**
      * Returns an associative map of static variables in the method/function body
+     *
+     * @return array<string, mixed>
      */
     public function getStaticVariables(): array
     {

--- a/src/ReflectionAttribute.php
+++ b/src/ReflectionAttribute.php
@@ -31,24 +31,38 @@ use ReflectionAttribute as BaseReflectionAttribute;
 class ReflectionAttribute extends BaseReflectionAttribute
 {
     /**
+     * Fully-qualified attribute class name.
+     *
+     * @var class-string<object>
+     */
+    private string $attributeName;
+
+    /**
+     * @param class-string<object> $attributeName
      * @param array<int, mixed> $arguments
      */
     public function __construct(
-        private string $attributeName,
+        string $attributeName,
         private ReflectionClass|ReflectionMethod|ReflectionProperty|ReflectionClassConstant|ReflectionFunction|ReflectionParameter $reflector,
         private array $arguments,
         private bool $isRepeated,
     ) {
+        $this->attributeName = $attributeName;
     }
 
     public function getNode(): Node\Attribute
     {
-        /** @var Class_|ClassMethod|PropertyItem|ClassConst|Function_|Param $node  */
-        $node = $this->reflector->getNode();
+        $reflectorNode = $this->reflector->getNode();
 
-        // attrGroups only exists in Property Stmt
-        if ($node instanceof PropertyItem) {
+        // attrGroups only exists in Property Stmt (not PropertyItem), so switch to the type node
+        if ($reflectorNode instanceof PropertyItem && $this->reflector instanceof ReflectionProperty) {
             $node = $this->reflector->getTypeNode();
+        } else {
+            $node = $reflectorNode;
+        }
+
+        if ($node instanceof PropertyItem) {
+            throw new ReflectionException('ReflectionAttribute cannot resolve attrGroups from a PropertyItem node');
         }
 
         $nodeExpressionResolver = new NodeExpressionResolver($this);

--- a/src/ReflectionAttribute.php
+++ b/src/ReflectionAttribute.php
@@ -71,7 +71,10 @@ class ReflectionAttribute extends BaseReflectionAttribute
                 $attributeNodeName = $attr->name;
                 // Unpack fully-resolved class name from attribute if we have it
                 if ($attributeNodeName->hasAttribute('resolvedName')) {
-                    $attributeNodeName = $attributeNodeName->getAttribute('resolvedName');
+                    $resolvedName = $attributeNodeName->getAttribute('resolvedName');
+                    if ($resolvedName instanceof \PhpParser\Node\Name) {
+                        $attributeNodeName = $resolvedName;
+                    }
                 }
                 if ($attributeNodeName->toString() !== $this->attributeName) {
                     continue;

--- a/src/ReflectionAttribute.php
+++ b/src/ReflectionAttribute.php
@@ -25,9 +25,14 @@ use ReflectionAttribute as BaseReflectionAttribute;
 
 /**
  * ref original usage https://3v4l.org/duaQI
+ *
+ * @extends \ReflectionAttribute<object>
  */
 class ReflectionAttribute extends BaseReflectionAttribute
 {
+    /**
+     * @param array<int, mixed> $arguments
+     */
     public function __construct(
         private string $attributeName,
         private ReflectionClass|ReflectionMethod|ReflectionProperty|ReflectionClassConstant|ReflectionFunction|ReflectionParameter $reflector,
@@ -82,6 +87,8 @@ class ReflectionAttribute extends BaseReflectionAttribute
 
     /**
      * {@inheritDoc}
+     *
+     * @return array<int, mixed>
      */
     public function getArguments(): array
     {

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -52,7 +52,7 @@ final class ReflectionClass extends InternalReflectionClass
         $fullClassName = is_object($argument) ? get_class($argument) : ltrim($argument, '\\');
         $namespaceParts  = explode('\\', $fullClassName);
         $shortName = array_pop($namespaceParts);
-        if ($shortName !== null && $shortName !== '') {
+        if ($shortName !== '') {
             $this->className = $shortName;
         } else {
             // Fallback: use the full class name if explode produced an empty short name
@@ -76,12 +76,12 @@ final class ReflectionClass extends InternalReflectionClass
     {
         $interfaces = [];
 
-        $isInterface    = $classLikeNode instanceof Interface_;
-
-        if ($isInterface) {
-            $implementsList = $classLikeNode instanceof Interface_ ? $classLikeNode->extends : [];
+        if ($classLikeNode instanceof Interface_) {
+            $implementsList = $classLikeNode->extends;
+        } elseif ($classLikeNode instanceof Class_) {
+            $implementsList = $classLikeNode->implements;
         } else {
-            $implementsList = $classLikeNode instanceof Class_ ? $classLikeNode->implements : [];
+            $implementsList = [];
         }
 
         if (count($implementsList) > 0) {
@@ -126,7 +126,7 @@ final class ReflectionClass extends InternalReflectionClass
             foreach ($classLikeNode->stmts as $classLevelNode) {
                 if ($classLevelNode instanceof TraitUse) {
                     foreach ($classLevelNode->traits as $classTraitName) {
-                        if ($classTraitName instanceof Name && $classTraitName->getAttribute('resolvedName') instanceof FullyQualified) {
+                        if ($classTraitName->getAttribute('resolvedName') instanceof FullyQualified) {
                             $traitName          = $classTraitName->getAttribute('resolvedName')->toString();
                             $trait              = trait_exists($traitName, false)
                                 ? new parent($traitName)

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -49,9 +49,16 @@ final class ReflectionClass extends InternalReflectionClass
      */
     public function __construct(object|string $argument, ?ClassLike $classLikeNode = null)
     {
-        $fullClassName   = is_object($argument) ? get_class($argument) : ltrim($argument, '\\');
+        $fullClassName = is_object($argument) ? get_class($argument) : ltrim($argument, '\\');
         $namespaceParts  = explode('\\', $fullClassName);
-        $this->className = array_pop($namespaceParts);
+        $shortName = array_pop($namespaceParts);
+        if ($shortName !== null && $shortName !== '') {
+            $this->className = $shortName;
+        } else {
+            // Fallback: use the full class name if explode produced an empty short name
+            // get_class() always returns non-empty, so this path handles edge cases only
+            $this->className = $fullClassName !== '' ? $fullClassName : 'UnknownClass';
+        }
         // Let's unset original read-only property to have a control over it via __get
         unset($this->name);
 
@@ -63,7 +70,7 @@ final class ReflectionClass extends InternalReflectionClass
     /**
      * Parses interfaces from the concrete class node
      *
-     * @return \ReflectionClass<object>[] List of reflections of interfaces
+     * @return array<string, \ReflectionClass<object>> List of reflections of interfaces
      */
     public static function collectInterfacesFromClassNode(ClassLike $classLikeNode): array
     {
@@ -97,7 +104,7 @@ final class ReflectionClass extends InternalReflectionClass
                 ? [\UnitEnum::class, \BackedEnum::class] // PHP Uses exactly this order, not reversed by parent!
                 : [\UnitEnum::class];
             foreach ($interfacesToAdd as $interfaceToAdd) {
-                $interfaces[$interfaceToAdd] = new parent($interfaceToAdd);
+                $interfaces[$interfaceToAdd] = self::createNativeReflectionClass($interfaceToAdd);
             }
         }
 
@@ -133,6 +140,17 @@ final class ReflectionClass extends InternalReflectionClass
         }
 
         return $traits;
+    }
+
+    /**
+     * Creates a native ReflectionClass instance for the given class/interface name.
+     *
+     * @param class-string<object> $className
+     * @return \ReflectionClass<object>
+     */
+    private static function createNativeReflectionClass(string $className): InternalReflectionClass
+    {
+        return new parent($className);
     }
 
     /**

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -26,7 +26,9 @@ use ReflectionClass as InternalReflectionClass;
 
 /**
  * AST-based reflection class
+ *
  * @see \Go\ParserReflection\ReflectionClassTest
+ * @extends \ReflectionClass<object>
  */
 final class ReflectionClass extends InternalReflectionClass
 {
@@ -61,7 +63,7 @@ final class ReflectionClass extends InternalReflectionClass
     /**
      * Parses interfaces from the concrete class node
      *
-     * @return InternalReflectionClass[] List of reflections of interfaces
+     * @return \ReflectionClass<object>[] List of reflections of interfaces
      */
     public static function collectInterfacesFromClassNode(ClassLike $classLikeNode): array
     {
@@ -105,9 +107,9 @@ final class ReflectionClass extends InternalReflectionClass
     /**
      * Parses traits from the concrete class node
      *
-     * @param array $traitAdaptations List of method adaptations
+     * @param array<int|string, \PhpParser\Node\Stmt\TraitUseAdaptation> $traitAdaptations List of method adaptations
      *
-     * @return InternalReflectionClass[] List of reflections of traits
+     * @return \ReflectionClass<object>[] List of reflections of traits
      */
     public static function collectTraitsFromClassNode(ClassLike $classLikeNode, array &$traitAdaptations): array
     {
@@ -164,7 +166,7 @@ final class ReflectionClass extends InternalReflectionClass
      *
      * @param string $className The name of the class to create a reflection for.
      *
-     * @return InternalReflectionClass The appropriate reflection object.
+     * @return \ReflectionClass<object> The appropriate reflection object.
      */
     protected function createReflectionForClass(string $className): InternalReflectionClass
     {

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -172,6 +172,14 @@ final class ReflectionClass extends InternalReflectionClass
     }
 
     /**
+     * Returns the AST node that contains attribute groups for this class.
+     */
+    protected function getNodeForAttributes(): ClassLike
+    {
+        return $this->classLikeNode;
+    }
+
+    /**
      * Implementation of internal reflection initialization
      */
     protected function __initialize(): void

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -17,6 +17,7 @@ use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Traits\ReflectionClassLikeTrait;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Interface_;
@@ -27,11 +28,16 @@ use ReflectionClass as InternalReflectionClass;
  * AST-based reflection class
  * @see \Go\ParserReflection\ReflectionClassTest
  */
-class ReflectionClass extends InternalReflectionClass
+final class ReflectionClass extends InternalReflectionClass
 {
     use InternalPropertiesEmulationTrait;
     use ReflectionClassLikeTrait;
     use AttributeResolverTrait;
+
+    /**
+     * Re-declare to remove parent's @readonly / PHP 8.4 hook so it can be unset in constructor
+     */
+    public string $name;
 
     /**
      * Initializes reflection instance
@@ -62,18 +68,20 @@ class ReflectionClass extends InternalReflectionClass
         $interfaces = [];
 
         $isInterface    = $classLikeNode instanceof Interface_;
-        $interfaceField = $isInterface ? 'extends' : 'implements';
 
-        $hasExplicitInterfaces = in_array($interfaceField, $classLikeNode->getSubNodeNames(), true);
-        $implementsList        = $hasExplicitInterfaces ? $classLikeNode->$interfaceField : [];
+        if ($isInterface) {
+            $implementsList = $classLikeNode instanceof Interface_ ? $classLikeNode->extends : [];
+        } else {
+            $implementsList = $classLikeNode instanceof Class_ ? $classLikeNode->implements : [];
+        }
 
         if (count($implementsList) > 0) {
             foreach ($implementsList as $implementNode) {
-                if ($implementNode instanceof Name && $implementNode->getAttribute('resolvedName') instanceof FullyQualified) {
+                if ($implementNode->getAttribute('resolvedName') instanceof FullyQualified) {
                     $implementName = $implementNode->getAttribute('resolvedName')->toString();
                     $interface     = interface_exists($implementName, false)
                         ? new parent($implementName)
-                        : new static($implementName);
+                        : new self($implementName);
 
                     $interfaces[$implementName] = $interface;
                 }
@@ -113,7 +121,7 @@ class ReflectionClass extends InternalReflectionClass
                             $traitName          = $classTraitName->getAttribute('resolvedName')->toString();
                             $trait              = trait_exists($traitName, false)
                                 ? new parent($traitName)
-                                : new static($traitName);
+                                : new self($traitName);
                             $traits[$traitName] = $trait;
                         }
                     }
@@ -138,7 +146,7 @@ class ReflectionClass extends InternalReflectionClass
     /**
      * Returns an AST-node for class
      */
-    public function getNode(): ?ClassLike
+    public function getNode(): ClassLike
     {
         return $this->classLikeNode;
     }
@@ -160,6 +168,6 @@ class ReflectionClass extends InternalReflectionClass
      */
     protected function createReflectionForClass(string $className): InternalReflectionClass
     {
-        return class_exists($className, false) ? new parent($className) : new static($className);
+        return class_exists($className, false) ? new parent($className) : new self($className);
     }
 }

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -100,6 +100,9 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
         if (!$classConstNode) {
             [$classConstNode, $constNode] = ReflectionEngine::parseClassConstant($className, $classConstantName);
         }
+        if ($constNode === null) {
+            throw new \InvalidArgumentException("Const node was not found for $className::$classConstantName");
+        }
         // Let's unset original read-only property to have a control over it via __get
         unset($this->name, $this->class);
 
@@ -114,7 +117,7 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
             $this->value = $expressionSolver->getValue();
         }
 
-        if ($this->hasType() && $this->classConstOrEnumCaseNode instanceof ClassConst) {
+        if ($this->hasType() && $this->classConstOrEnumCaseNode instanceof ClassConst && $this->classConstOrEnumCaseNode->type !== null) {
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->getValue() === null;
 
@@ -274,7 +277,7 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
             }
             $valueType = new ReflectionType($type, false);
         } else {
-            $valueType = $this->type;
+            $valueType = $this->type ?? new ReflectionType('mixed', false);
         }
 
         return sprintf(

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -26,10 +26,16 @@ use ReflectionClassConstant as BaseReflectionClassConstant;
 /**
  * @see \Go\ParserReflection\ReflectionClassConstantTest
  */
-class ReflectionClassConstant extends BaseReflectionClassConstant
+final class ReflectionClassConstant extends BaseReflectionClassConstant
 {
     use InternalPropertiesEmulationTrait;
     use AttributeResolverTrait;
+
+    /**
+     * Re-declare to remove PHP 8.4 { get; } hooks so these properties can be unset in constructor
+     */
+    public string $name;
+    public string $class;
 
     /**
      * Concrete class constant node
@@ -57,7 +63,7 @@ class ReflectionClassConstant extends BaseReflectionClassConstant
             if ($classLevelNode instanceof ClassConst) {
                 foreach ($classLevelNode->consts as $const) {
                     $classConstName = $const->name->toString();
-                    $classConstants[$classConstName] = new static(
+                    $classConstants[$classConstName] = new self(
                         $reflectionClassFQN,
                         $classConstName,
                         $classLevelNode,
@@ -112,7 +118,7 @@ class ReflectionClassConstant extends BaseReflectionClassConstant
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->getValue() === null;
 
-            $typeResolver = new TypeExpressionResolver($this->getDeclaringClass());
+            $typeResolver = new TypeExpressionResolver();
             $typeResolver->process($this->classConstOrEnumCaseNode->type, $hasDefaultNull);
 
             $this->type = $typeResolver->getType();

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -109,12 +109,12 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
         $expressionSolver = new NodeExpressionResolver($this->getDeclaringClass());
 
         // We can statically resolve value only fot ClassConst, as for EnumCase we need to have object itself as default
-        if ($classConstNode instanceof ClassConst) {
+        if ($classConstNode instanceof ClassConst && $this->constOrEnumCaseNode instanceof Const_) {
             $expressionSolver->process($this->constOrEnumCaseNode->value);
             $this->value = $expressionSolver->getValue();
         }
 
-        if ($this->hasType()) {
+        if ($this->hasType() && $this->classConstOrEnumCaseNode instanceof ClassConst) {
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->getValue() === null;
 

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -53,7 +53,7 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
     /**
      * Parses class constants from the concrete class node
      *
-     * @return ReflectionClassConstant[]
+     * @return array<string, ReflectionClassConstant>
      */
     public static function collectFromClassNode(ClassLike $classLikeNode, string $reflectionClassFQN): array
     {
@@ -259,7 +259,7 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
     public function __toString(): string
     {
         # Starting from PHP7.3 gettype returns different names, need to remap them
-        static $typeMap = [
+        $typeMap = [
             'integer' => 'int',
             'boolean' => 'bool',
             'double'  => 'float',
@@ -290,6 +290,14 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
     }
 
     public function getNode(): ClassConst|EnumCase
+    {
+        return $this->classConstOrEnumCaseNode;
+    }
+
+    /**
+     * Returns the AST node that contains attribute groups for this class constant.
+     */
+    protected function getNodeForAttributes(): ClassConst|EnumCase
     {
         return $this->classConstOrEnumCaseNode;
     }

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -138,6 +138,8 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
 
     /**
      * @inheritDoc
+     *
+     * @return \ReflectionClass<object>
      */
     public function getDeclaringClass(): \ReflectionClass
     {

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -285,7 +285,7 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
             implode(' ', Reflection::getModifierNames($this->getModifiers())),
             ReflectionType::convertToDisplayType($valueType),
             $this->getName(),
-            is_object($value) ? 'Object' : $value
+            is_object($value) ? 'Object' : (is_scalar($value) || $value === null ? $value : '')
         );
     }
 

--- a/src/ReflectionClassConstant.php
+++ b/src/ReflectionClassConstant.php
@@ -121,7 +121,11 @@ final class ReflectionClassConstant extends BaseReflectionClassConstant
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->getValue() === null;
 
-            $typeResolver = new TypeExpressionResolver();
+            $declaringClass  = $this->getDeclaringClass();
+            $parentClass     = $declaringClass->getParentClass();
+            $parentClassName = ($parentClass !== false) ? $parentClass->getName() : null;
+
+            $typeResolver = new TypeExpressionResolver($this->className, $parentClassName);
             $typeResolver->process($this->classConstOrEnumCaseNode->type, $hasDefaultNull);
 
             $this->type = $typeResolver->getType();

--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -128,6 +128,9 @@ class ReflectionEngine
      *
      * @see https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf
      */
+    /**
+     * @param Node[] $nodes
+     */
     protected static function findClassLikeNodeByClassName(array $nodes, string $className): ?ClassLike
     {
         foreach ($nodes as $node) {
@@ -170,7 +173,7 @@ class ReflectionEngine
     /**
      * Parses class property
      *
-     * @return array Pair of [Property and PropertyItem] nodes
+     * @return array{0: \PhpParser\Node\Stmt\Property, 1: \PhpParser\Node\PropertyItem} Pair of [Property and PropertyItem] nodes
      */
     public static function parseClassProperty(string $fullClassName, string $propertyName): array
     {
@@ -193,7 +196,7 @@ class ReflectionEngine
     /**
      * Parses class constants
      *
-     * @return array Pair of [ClassConst and Const_] nodes
+     * @return array{0: \PhpParser\Node\Stmt\ClassConst|\PhpParser\Node\Stmt\EnumCase, 1: \PhpParser\Node\Const_|\PhpParser\Node\Stmt\EnumCase} Pair of [ClassConst and Const_] nodes
      */
     public static function parseClassConstant(string $fullClassName, string $constantName): array
     {

--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -225,7 +225,8 @@ class ReflectionEngine
      */
     public static function parseFile(string $fileName, ?string $fileContent = null): array
     {
-        $fileName = PathResolver::realpath($fileName);
+        $resolvedFileName = PathResolver::realpath($fileName);
+        $fileName = is_string($resolvedFileName) ? $resolvedFileName : $fileName;
         if (isset(self::$parsedFiles[$fileName]) && !isset($fileContent)) {
             return self::$parsedFiles[$fileName];
         }
@@ -236,6 +237,9 @@ class ReflectionEngine
 
         if (!isset($fileContent)) {
             $fileContent = file_get_contents($fileName);
+            if ($fileContent === false) {
+                throw new ReflectionException("Could not read file: $fileName");
+            }
         }
         $treeNodes = self::$parser->parse($fileContent);
         $treeNodes = self::$traverser->traverse($treeNodes);

--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -86,6 +86,9 @@ class ReflectionEngine
             $refClass      = new \ReflectionClass($fullClassName);
             $classFileName = $refClass->getFileName();
         } else {
+            if (self::$locator === null) {
+                throw new \LogicException('ReflectionEngine locator is not initialized. Call ReflectionEngine::init() first.');
+            }
             $classFileName = self::$locator->locateClass($fullClassName);
         }
 
@@ -134,7 +137,7 @@ class ReflectionEngine
     protected static function findClassLikeNodeByClassName(array $nodes, string $className): ?ClassLike
     {
         foreach ($nodes as $node) {
-            if ($node instanceof ClassLike && $node->name->toString() == $className) {
+            if ($node instanceof ClassLike && $node->name !== null && $node->name->toString() == $className) {
                 return $node;
             }
             if ($node instanceof Node\Stmt\If_
@@ -241,7 +244,7 @@ class ReflectionEngine
                 throw new ReflectionException("Could not read file: $fileName");
             }
         }
-        $treeNodes = self::$parser->parse($fileContent);
+        $treeNodes = self::$parser->parse($fileContent) ?? [];
         $treeNodes = self::$traverser->traverse($treeNodes);
 
         self::$parsedFiles[$fileName] = $treeNodes;

--- a/src/ReflectionEngine.php
+++ b/src/ReflectionEngine.php
@@ -142,8 +142,7 @@ class ReflectionEngine
             }
             if ($node instanceof Node\Stmt\If_
                 && $node->cond instanceof Node\Expr\ConstFetch
-                && isset($node->cond->name->parts[0])
-                && $node->cond->name->parts[0] === 'false'
+                && $node->cond->name->toString() === 'false'
             ) {
                 $result = self::findClassLikeNodeByClassName($node->stmts, $className);
 

--- a/src/ReflectionFile.php
+++ b/src/ReflectionFile.php
@@ -50,9 +50,9 @@ class ReflectionFile
      */
     public function __construct(string $fileName, ?array $topLevelNodes = null)
     {
-        $fileName            = PathResolver::realpath($fileName);
-        $this->fileName      = $fileName;
-        $this->topLevelNodes = $topLevelNodes ?: ReflectionEngine::parseFile($fileName);
+        $resolvedFileName    = PathResolver::realpath($fileName);
+        $this->fileName      = is_string($resolvedFileName) ? $resolvedFileName : $fileName;
+        $this->topLevelNodes = $topLevelNodes ?: ReflectionEngine::parseFile($this->fileName);
     }
 
     /**
@@ -123,6 +123,9 @@ class ReflectionFile
         }
 
         $declareStatement = reset($topLevelNode->declares);
+        if ($declareStatement === false) {
+            return false;
+        }
         $isStrictTypeKey  = $declareStatement->key->toString() === 'strict_types';
         $isScalarValue    = $declareStatement->value instanceof Node\Scalar\Int_;
         $isStrictMode     = $isStrictTypeKey && $isScalarValue && $declareStatement->value->value === 1;

--- a/src/ReflectionFileNamespace.php
+++ b/src/ReflectionFileNamespace.php
@@ -164,7 +164,7 @@ class ReflectionFileNamespace
         $docComment = false;
         $comments   = $this->namespaceNode->getAttribute('comments');
 
-        if ($comments) {
+        if (is_array($comments) && isset($comments[0]) && ($comments[0] instanceof \PhpParser\Comment || is_string($comments[0]))) {
             $docComment = (string)$comments[0];
         }
 
@@ -176,11 +176,9 @@ class ReflectionFileNamespace
      */
     public function getEndLine(): int|false
     {
-        if ($this->namespaceNode->hasAttribute('endLine')) {
-            return $this->namespaceNode->getAttribute('endLine');
-        }
+        $endLine = $this->namespaceNode->getAttribute('endLine');
 
-        return false;
+        return is_int($endLine) ? $endLine : false;
     }
 
     /**
@@ -258,11 +256,13 @@ class ReflectionFileNamespace
      */
     public function getLastTokenPosition(): int
     {
-        $endNamespaceTokenPosition = $this->namespaceNode->getAttribute('endTokenPos');
+        $endNamespaceTokenPosRaw = $this->namespaceNode->getAttribute('endTokenPos');
+        $endNamespaceTokenPosition = is_int($endNamespaceTokenPosRaw) ? $endNamespaceTokenPosRaw : 0;
 
         /** @var Node $lastNamespaceNode */
         $lastNamespaceNode         = end($this->namespaceNode->stmts);
-        $endStatementTokenPosition = $lastNamespaceNode->getAttribute('endTokenPos');
+        $endStatementTokenPosRaw   = $lastNamespaceNode->getAttribute('endTokenPos');
+        $endStatementTokenPosition = is_int($endStatementTokenPosRaw) ? $endStatementTokenPosRaw : 0;
 
         return max($endNamespaceTokenPosition, $endStatementTokenPosition);
     }
@@ -272,11 +272,9 @@ class ReflectionFileNamespace
      */
     public function getStartLine(): int|false
     {
-        if ($this->namespaceNode->hasAttribute('startLine')) {
-            return $this->namespaceNode->getAttribute('startLine');
-        }
+        $startLine = $this->namespaceNode->getAttribute('startLine');
 
-        return false;
+        return is_int($startLine) ? $startLine : false;
     }
 
     /**
@@ -401,6 +399,9 @@ class ReflectionFileNamespace
                         $expressionSolver->process($arg1->value);
                         $constantValue = $expressionSolver->getValue();
 
+                        if (!is_string($constantName)) {
+                            continue;
+                        }
                         $constants[$constantName] = $constantValue;
                     } catch (\Throwable) {
                         // Ignore all possible errors during evaluation of runtime constants defined in the code

--- a/src/ReflectionFileNamespace.php
+++ b/src/ReflectionFileNamespace.php
@@ -320,7 +320,7 @@ class ReflectionFileNamespace
         $namespaceName = $this->getName();
         // classes can be only top-level nodes in the namespace, so we can scan them directly
         foreach ($this->namespaceNode->stmts as $namespaceLevelNode) {
-            if ($namespaceLevelNode instanceof ClassLike) {
+            if ($namespaceLevelNode instanceof ClassLike && $namespaceLevelNode->name !== null) {
                 $classShortName = $namespaceLevelNode->name->toString();
                 $className = $namespaceName ? $namespaceName .'\\' . $classShortName : $classShortName;
 

--- a/src/ReflectionFileNamespace.php
+++ b/src/ReflectionFileNamespace.php
@@ -81,7 +81,8 @@ class ReflectionFileNamespace
      */
     public function __construct(string $fileName, string $namespaceName, ?Namespace_ $namespaceNode = null)
     {
-        $fileName = PathResolver::realpath($fileName);
+        $resolvedFileName = PathResolver::realpath($fileName);
+        $fileName = is_string($resolvedFileName) ? $resolvedFileName : $fileName;
         if (!isset($namespaceNode)) {
             $namespaceNode = ReflectionEngine::parseFileNamespace($fileName, $namespaceName);
         }
@@ -389,10 +390,15 @@ class ReflectionFileNamespace
                 ) {
                     try {
                         $functionCallNode = $namespaceLevelNode->expr;
-                        $expressionSolver->process($functionCallNode->args[0]->value);
+                        $arg0 = $functionCallNode->args[0];
+                        $arg1 = $functionCallNode->args[1];
+                        if (!$arg0 instanceof \PhpParser\Node\Arg || !$arg1 instanceof \PhpParser\Node\Arg) {
+                            continue;
+                        }
+                        $expressionSolver->process($arg0->value);
                         $constantName = $expressionSolver->getValue();
 
-                        $expressionSolver->process($functionCallNode->args[1]->value);
+                        $expressionSolver->process($arg1->value);
                         $constantValue = $expressionSolver->getValue();
 
                         $constants[$constantName] = $constantValue;

--- a/src/ReflectionFileNamespace.php
+++ b/src/ReflectionFileNamespace.php
@@ -45,16 +45,22 @@ class ReflectionFileNamespace
 
     /**
      * Map of constants in the namespace
+     *
+     * @var array<string, mixed>
      */
     protected array $fileConstants;
 
     /**
      * Map of constants in the namespace including defined via "define(...)"
+     *
+     * @var array<string, mixed>
      */
     protected array $fileConstantsWithDefined;
 
     /**
      * List of imported namespaces (aliases)
+     *
+     * @var array<string, string>
      */
     protected array $fileNamespaceAliases;
 
@@ -129,6 +135,8 @@ class ReflectionFileNamespace
      * Returns a list of defined constants in the namespace
      *
      * @param bool $withDefined Include constants defined via "define(...)" in results.
+     *
+     * @return array<string, mixed>
      */
     public function getConstants(bool $withDefined = false): array
     {
@@ -222,6 +230,8 @@ class ReflectionFileNamespace
 
     /**
      * Returns a list of namespace aliases
+     *
+     * @return array<string, string>
      */
     public function getNamespaceAliases(): array
     {
@@ -349,6 +359,8 @@ class ReflectionFileNamespace
      * Searches for constants in the given AST
      *
      * @param bool $withDefined Include constants defined via "define(...)" in results.
+     *
+     * @return array<string, mixed>
      */
     private function findConstants(bool $withDefined = false): array
     {
@@ -396,6 +408,8 @@ class ReflectionFileNamespace
 
     /**
      * Searches for namespace aliases for the current block
+     *
+     * @return array<string, string>
      */
     private function findNamespaceAliases(): array
     {

--- a/src/ReflectionFileNamespace.php
+++ b/src/ReflectionFileNamespace.php
@@ -391,7 +391,7 @@ class ReflectionFileNamespace
                         $arg0 = $functionCallNode->args[0];
                         $arg1 = $functionCallNode->args[1];
                         if (!$arg0 instanceof \PhpParser\Node\Arg || !$arg1 instanceof \PhpParser\Node\Arg) {
-                            continue;
+                            throw new ReflectionException('define() call uses unsupported argument type (e.g. variadic placeholder)');
                         }
                         $expressionSolver->process($arg0->value);
                         $constantName = $expressionSolver->getValue();
@@ -400,7 +400,7 @@ class ReflectionFileNamespace
                         $constantValue = $expressionSolver->getValue();
 
                         if (!is_string($constantName)) {
-                            continue;
+                            throw new ReflectionException(sprintf('define() constant name must be a string, got %s', gettype($constantName)));
                         }
                         $constants[$constantName] = $constantValue;
                     } catch (\Throwable) {

--- a/src/ReflectionFunction.php
+++ b/src/ReflectionFunction.php
@@ -74,6 +74,14 @@ final class ReflectionFunction extends BaseReflectionFunction
     }
 
     /**
+     * Returns the AST node that contains attribute groups for this function.
+     */
+    protected function getNodeForAttributes(): Function_
+    {
+        return $this->getNode();
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClosure(): \Closure

--- a/src/ReflectionFunction.php
+++ b/src/ReflectionFunction.php
@@ -47,6 +47,8 @@ final class ReflectionFunction extends BaseReflectionFunction
 
     /**
      * Emulating original behaviour of reflection
+     *
+     * @return array<string, string>
      */
     public function __debugInfo(): array
     {
@@ -93,6 +95,8 @@ final class ReflectionFunction extends BaseReflectionFunction
 
     /**
      * {@inheritDoc}
+     *
+     * @param array<int, mixed> $args
      */
     public function invokeArgs(array $args): mixed
     {

--- a/src/ReflectionFunction.php
+++ b/src/ReflectionFunction.php
@@ -15,7 +15,6 @@ use Closure;
 use Go\ParserReflection\Traits\AttributeResolverTrait;
 use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Traits\ReflectionFunctionLikeTrait;
-use JetBrains\PhpStorm\Deprecated;
 use PhpParser\Node\Stmt\Function_;
 use ReflectionFunction as BaseReflectionFunction;
 
@@ -23,7 +22,7 @@ use ReflectionFunction as BaseReflectionFunction;
  * AST-based reflection for function
  * @see \Go\ParserReflection\ReflectionFunctionTest
  */
-class ReflectionFunction extends BaseReflectionFunction
+final class ReflectionFunction extends BaseReflectionFunction
 {
     use InternalPropertiesEmulationTrait;
     use ReflectionFunctionLikeTrait;
@@ -65,6 +64,10 @@ class ReflectionFunction extends BaseReflectionFunction
      */
     public function getNode(): Function_
     {
+        if (!$this->functionLikeNode instanceof Function_) {
+            throw new \LogicException('Expected Function_ node');
+        }
+
         return $this->functionLikeNode;
     }
 
@@ -104,7 +107,7 @@ class ReflectionFunction extends BaseReflectionFunction
      * Only internal functions can be disabled using disable_functions directive.
      * User-defined functions are unaffected.
      */
-    #[Deprecated('ReflectionFunction::isDisabled() is deprecated', since: "8.0")]
+    #[\Deprecated('ReflectionFunction::isDisabled() is deprecated', since: "8.0")]
     public function isDisabled(): bool
     {
         return false;
@@ -118,6 +121,11 @@ class ReflectionFunction extends BaseReflectionFunction
         $paramFormat      = ($this->getNumberOfParameters() > 0) ? "\n\n  - Parameters [%d] {%s\n  }" : '';
         $reflectionFormat = "%sFunction [ <user> function %s ] {\n  @@ %s %d - %d{$paramFormat}\n}\n";
 
+        $paramStr = '';
+        foreach ($this->getParameters() as $param) {
+            $paramStr .= "\n    " . $param;
+        }
+
         return sprintf(
             $reflectionFormat,
             $this->getDocComment() ? $this->getDocComment() . "\n" : '',
@@ -126,7 +134,7 @@ class ReflectionFunction extends BaseReflectionFunction
             $this->getStartLine(),
             $this->getEndLine(),
             count($this->getParameters()),
-            array_reduce($this->getParameters(), static fn($str, ReflectionParameter $param) => $str . "\n    " . $param, '')
+            $paramStr
         );
     }
 

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -63,6 +63,18 @@ final class ReflectionMethod extends BaseReflectionMethod
         unset($this->name, $this->class);
     }
 
+    protected function getDeclaringClassNameForTypes(): string
+    {
+        return $this->getDeclaringClass()->getName();
+    }
+
+    protected function getParentClassNameForTypes(): ?string
+    {
+        $parent = $this->getDeclaringClass()->getParentClass();
+
+        return ($parent !== false) ? $parent->getName() : null;
+    }
+
     /**
      * Returns an AST-node for method
      */

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -72,6 +72,14 @@ final class ReflectionMethod extends BaseReflectionMethod
     }
 
     /**
+     * Returns the AST node that contains attribute groups for this method.
+     */
+    protected function getNodeForAttributes(): ClassMethod
+    {
+        return $this->getClassMethodNode();
+    }
+
+    /**
      * Emulating original behaviour of reflection
      *
      * @return array<string, string>
@@ -166,6 +174,31 @@ final class ReflectionMethod extends BaseReflectionMethod
     public function getDeclaringClass(): \ReflectionClass
     {
         return $this->declaringClass ?? new ReflectionClass($this->className);
+    }
+
+    /**
+     * Checks if this method is an Enum magic method (cases/from/tryFrom).
+     */
+    private function isEnumMagicMethod(): bool
+    {
+        return $this->getDeclaringClass()->isEnum()
+            && in_array($this->getName(), ['cases', 'tryFrom', 'from'], true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInternal(): bool
+    {
+        return $this->isEnumMagicMethod();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isUserDefined(): bool
+    {
+        return !$this->isEnumMagicMethod();
     }
 
     /**
@@ -336,7 +369,7 @@ final class ReflectionMethod extends BaseReflectionMethod
      * @param ClassLike $classLikeNode Class-like node
      * @param ReflectionClass $reflectionClass Reflection of the class
      *
-     * @return ReflectionMethod[]
+     * @return array<string, ReflectionMethod>
      */
     public static function collectFromClassNode(ClassLike $classLikeNode, ReflectionClass $reflectionClass): array
     {

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -73,6 +73,8 @@ final class ReflectionMethod extends BaseReflectionMethod
 
     /**
      * Emulating original behaviour of reflection
+     *
+     * @return array<string, string>
      */
     public function __debugInfo(): array
     {
@@ -158,6 +160,8 @@ final class ReflectionMethod extends BaseReflectionMethod
 
     /**
      * {@inheritDoc}
+     *
+     * @return \ReflectionClass<object>
      */
     public function getDeclaringClass(): \ReflectionClass
     {
@@ -244,6 +248,8 @@ final class ReflectionMethod extends BaseReflectionMethod
 
     /**
      * {@inheritDoc}
+     *
+     * @param array<int, mixed> $args
      */
     public function invokeArgs(?object $object, array $args): mixed
     {

--- a/src/ReflectionMethod.php
+++ b/src/ReflectionMethod.php
@@ -14,7 +14,6 @@ namespace Go\ParserReflection;
 use Go\ParserReflection\Traits\AttributeResolverTrait;
 use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Traits\ReflectionFunctionLikeTrait;
-use JetBrains\PhpStorm\Deprecated;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -27,7 +26,7 @@ use ReflectionMethod as BaseReflectionMethod;
  * AST-based reflection for the method in a class
  * @see \Go\ParserReflection\ReflectionMethodTest
  */
-class ReflectionMethod extends BaseReflectionMethod
+final class ReflectionMethod extends BaseReflectionMethod
 {
     use InternalPropertiesEmulationTrait;
     use ReflectionFunctionLikeTrait;
@@ -69,7 +68,7 @@ class ReflectionMethod extends BaseReflectionMethod
      */
     public function getNode(): ClassMethod
     {
-        return $this->functionLikeNode;
+        return $this->getClassMethodNode();
     }
 
     /**
@@ -320,7 +319,7 @@ class ReflectionMethod extends BaseReflectionMethod
     /**
      * {@inheritDoc}
      */
-    #[Deprecated(reason: "Usage of ReflectionMethod::setAccessible() has no effect.", since: "8.1")]
+    #[\Deprecated("Usage of ReflectionMethod::setAccessible() has no effect.", since: "8.1")]
     public function setAccessible(bool $accessible): void
     {
     }
@@ -383,7 +382,7 @@ class ReflectionMethod extends BaseReflectionMethod
             ->setReturnType('array')
             ->getNode();
         
-        return new static(
+        return new self(
             $reflectionClass->name,
             'cases',
             $casesMethodNode,
@@ -403,7 +402,7 @@ class ReflectionMethod extends BaseReflectionMethod
             ->setReturnType('static')
             ->getNode();
 
-        return new static(
+        return new self(
             $reflectionClass->name,
             'from',
             $fromMethodNode,
@@ -423,7 +422,7 @@ class ReflectionMethod extends BaseReflectionMethod
             ->setReturnType('?static')
             ->getNode();
 
-        return new static(
+        return new self(
             $reflectionClass->name,
             'tryFrom',
             $fromMethodNode,
@@ -436,6 +435,10 @@ class ReflectionMethod extends BaseReflectionMethod
      */
     private function getClassMethodNode(): ClassMethod
     {
+        if (!$this->functionLikeNode instanceof ClassMethod) {
+            throw new \LogicException('Expected ClassMethod node');
+        }
+
         return $this->functionLikeNode;
     }
 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -118,7 +118,12 @@ final class ReflectionParameter extends BaseReflectionParameter
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->isDefaultValueAvailable() && $this->getDefaultValue() === null;
 
-            $typeResolver = new TypeExpressionResolver();
+            $declaringClass = $declaringFunction instanceof \ReflectionMethod ? $declaringFunction->getDeclaringClass() : null;
+            $selfClassName  = $declaringClass?->getName();
+            $parentClass    = $declaringClass?->getParentClass();
+            $parentClassName = ($parentClass !== false && $parentClass !== null) ? $parentClass->getName() : null;
+
+            $typeResolver = new TypeExpressionResolver($selfClassName, $parentClassName);
             $typeResolver->process($this->parameterNode->type, $hasDefaultNull);
 
             $this->type = $typeResolver->getType();

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -97,8 +97,10 @@ final class ReflectionParameter extends BaseReflectionParameter
 
         if ($declaringFunction instanceof \ReflectionMethod) {
             $context = $declaringFunction->getDeclaringClass();
-        } else {
+        } elseif ($declaringFunction instanceof \ReflectionFunction) {
             $context = $declaringFunction;
+        } else {
+            $context = null;
         }
 
         if ($this->isDefaultValueAvailable()) {
@@ -136,8 +138,10 @@ final class ReflectionParameter extends BaseReflectionParameter
      */
     public function __debugInfo(): array
     {
+        $varName = $this->parameterNode->var instanceof Expr\Variable ? $this->parameterNode->var->name : '';
+
         return [
-            'name' => (string)$this->parameterNode->var->name,
+            'name' => is_string($varName) ? $varName : '',
         ];
     }
 
@@ -221,7 +225,9 @@ final class ReflectionParameter extends BaseReflectionParameter
                 }
 
                 if ('parent' === $parameterTypeName) {
-                    return $this->getDeclaringClass()->getParentClass();
+                    $parentClass = $this->getDeclaringClass()->getParentClass();
+
+                    return $parentClass !== false ? $parentClass : null;
                 }
 
                 throw new ReflectionException("Can not resolve a class name for parameter");
@@ -287,7 +293,9 @@ final class ReflectionParameter extends BaseReflectionParameter
      */
     public function getName(): string
     {
-        return (string)$this->parameterNode->var->name;
+        $varName = $this->parameterNode->var instanceof Expr\Variable ? $this->parameterNode->var->name : '';
+
+        return is_string($varName) ? $varName : '';
     }
 
     /**

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -103,7 +103,7 @@ final class ReflectionParameter extends BaseReflectionParameter
             $context = null;
         }
 
-        if ($this->isDefaultValueAvailable()) {
+        if ($this->isDefaultValueAvailable() && $this->parameterNode->default !== null) {
             $expressionSolver = new NodeExpressionResolver($context);
             $expressionSolver->process($this->parameterNode->default);
 
@@ -114,7 +114,7 @@ final class ReflectionParameter extends BaseReflectionParameter
             $this->defaultValueConstExpr    = $expressionSolver->getConstExpression();
         }
 
-        if ($this->hasType()) {
+        if ($this->hasType() && $this->parameterNode->type !== null) {
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->isDefaultValueAvailable() && $this->getDefaultValue() === null;
 
@@ -183,7 +183,7 @@ final class ReflectionParameter extends BaseReflectionParameter
     public function allowsNull(): bool
     {
         // All non-typed parameters allows null by default
-        if (!$this->hasType()) {
+        if (!$this->hasType() || $this->type === null) {
             return true;
         }
 
@@ -225,7 +225,11 @@ final class ReflectionParameter extends BaseReflectionParameter
                 }
 
                 if ('parent' === $parameterTypeName) {
-                    $parentClass = $this->getDeclaringClass()->getParentClass();
+                    $declaringClass = $this->getDeclaringClass();
+                    if ($declaringClass === null) {
+                        return null;
+                    }
+                    $parentClass = $declaringClass->getParentClass();
 
                     return $parentClass !== false ? $parentClass : null;
                 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -214,7 +214,10 @@ final class ReflectionParameter extends BaseReflectionParameter
         if ($parameterType instanceof Name) {
             // If we have resolved type name, we should use it instead
             if ($parameterType->hasAttribute('resolvedName')) {
-                $parameterType = $parameterType->getAttribute('resolvedName');
+                $resolvedName = $parameterType->getAttribute('resolvedName');
+                if ($resolvedName instanceof Name) {
+                    $parameterType = $resolvedName;
+                }
             }
 
             if (!$parameterType instanceof Name\FullyQualified) {

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -15,7 +15,6 @@ use Go\ParserReflection\Traits\AttributeResolverTrait;
 use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use Go\ParserReflection\Resolver\TypeExpressionResolver;
-use JetBrains\PhpStorm\Deprecated;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp\Concat;
@@ -33,10 +32,15 @@ use ReflectionParameter as BaseReflectionParameter;
  * AST-based reflection for method/function parameter
  * @see \Go\ParserReflection\ReflectionParameterTest
  */
-class ReflectionParameter extends BaseReflectionParameter
+final class ReflectionParameter extends BaseReflectionParameter
 {
     use InternalPropertiesEmulationTrait;
     use AttributeResolverTrait;
+
+    /**
+     * Re-declare to remove PHP 8.4 { get; } hook so it can be unset in constructor
+     */
+    public string $name;
 
     /**
      * Reflection function or method
@@ -80,8 +84,6 @@ class ReflectionParameter extends BaseReflectionParameter
      * Initializes a reflection for the property
      */
     public function __construct(
-        string|array $unusedFunctionName,
-        string $parameterName,
         Param $parameterNode,
         int $parameterIndex,
         ReflectionFunctionAbstract $declaringFunction
@@ -114,7 +116,7 @@ class ReflectionParameter extends BaseReflectionParameter
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->isDefaultValueAvailable() && $this->getDefaultValue() === null;
 
-            $typeResolver = new TypeExpressionResolver($this->getDeclaringClass());
+            $typeResolver = new TypeExpressionResolver();
             $typeResolver->process($this->parameterNode->type, $hasDefaultNull);
 
             $this->type = $typeResolver->getType();
@@ -195,7 +197,7 @@ class ReflectionParameter extends BaseReflectionParameter
     /**
      * @inheritDoc
      */
-    #[Deprecated(reason: "Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead.", since: "8.0")]
+    #[\Deprecated("Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead.", since: "8.0")]
     public function getClass(): ?\ReflectionClass
     {
         $parameterType = $this->parameterNode->type;
@@ -311,7 +313,7 @@ class ReflectionParameter extends BaseReflectionParameter
     /**
      * @inheritDoc
      */
-    #[Deprecated(reason: "Use ReflectionParameter::getType() instead.", since: "8.0")]
+    #[\Deprecated("Use ReflectionParameter::getType() instead.", since: "8.0")]
     public function isArray(): bool
     {
         $type = $this->parameterNode->type;
@@ -322,7 +324,7 @@ class ReflectionParameter extends BaseReflectionParameter
     /**
      * @inheritDoc
      */
-    #[Deprecated(reason: "Use ReflectionParameter::getType() instead.", since: "8.0")]
+    #[\Deprecated("Use ReflectionParameter::getType() instead.", since: "8.0")]
     public function isCallable(): bool
     {
         $type = $this->parameterNode->type;
@@ -385,7 +387,11 @@ class ReflectionParameter extends BaseReflectionParameter
     {
         // start from PHP 8.1, isDefaultValueAvailable() returns false if next parameter is required
         // see https://github.com/php/php-src/issues/8090
-        $parameters = $this->declaringFunction->getNode()->getParams();
+        $fn = $this->declaringFunction;
+        if (!$fn instanceof ReflectionFunction && !$fn instanceof ReflectionMethod) {
+            return true;
+        }
+        $parameters = $fn->getNode()->getParams();
         for ($nextParamIndex = $this->parameterIndex + 1; $nextParamIndex < count($parameters); ++$nextParamIndex) {
             if (!isset($parameters[$nextParamIndex]->default) && !$parameters[$nextParamIndex]->variadic) {
                 return false;

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -134,6 +134,14 @@ final class ReflectionParameter extends BaseReflectionParameter
     }
 
     /**
+     * Returns the AST node that contains attribute groups for this parameter.
+     */
+    protected function getNodeForAttributes(): Param
+    {
+        return $this->parameterNode;
+    }
+
+    /**
      * Emulating original behaviour of reflection
      */
     public function __debugInfo(): array

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -196,6 +196,8 @@ final class ReflectionParameter extends BaseReflectionParameter
 
     /**
      * @inheritDoc
+     *
+     * @return \ReflectionClass<object>|null
      */
     #[\Deprecated("Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead.", since: "8.0")]
     public function getClass(): ?\ReflectionClass
@@ -236,6 +238,8 @@ final class ReflectionParameter extends BaseReflectionParameter
 
     /**
      * {@inheritDoc}
+     *
+     * @return \ReflectionClass<object>|null
      */
     public function getDeclaringClass(): ?\ReflectionClass
     {

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -219,16 +219,16 @@ final class ReflectionProperty extends BaseReflectionProperty
         if ($this->isReadOnly()) {
             $modifiers += self::IS_READONLY;
         }
-        if (PHP_VERSION_ID >= 80400 && $this->isAbstract()) {
+        if ($this->isAbstract()) {
             $modifiers += self::IS_ABSTRACT;
         }
-        if (PHP_VERSION_ID >= 80400 && $this->isFinal()) {
+        if ($this->isFinal()) {
             $modifiers += self::IS_FINAL;
         }
-        if (PHP_VERSION_ID >= 80400 && $this->isProtectedSet()) {
+        if ($this->isProtectedSet()) {
             $modifiers += self::IS_PROTECTED_SET;
         }
-        if (PHP_VERSION_ID >= 80400 && $this->isPrivateSet()) {
+        if ($this->isPrivateSet()) {
             $modifiers += self::IS_PRIVATE_SET;
         }
 
@@ -491,10 +491,13 @@ final class ReflectionProperty extends BaseReflectionProperty
     {
         $this->initializeInternalReflection();
 
-        if ($objectOrValue !== null && !is_object($objectOrValue)) {
-            throw new \InvalidArgumentException('Expected object or null for $objectOrValue');
+        if (!$this->isStatic() && $objectOrValue !== null && !is_object($objectOrValue)) {
+            throw new \InvalidArgumentException('Expected object or null for $objectOrValue on non-static property');
         }
-        parent::setValue($objectOrValue, $value);
+        // For static properties the object argument must be null; for instance properties it must be an object.
+        // After the guard above we know: isStatic() || objectOrValue === null || is_object(objectOrValue).
+        $objectArg = is_object($objectOrValue) ? $objectOrValue : null;
+        parent::setValue($objectArg, $value);
     }
 
     /**

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -97,7 +97,7 @@ final class ReflectionProperty extends BaseReflectionProperty
             $this->defaultValueConstExpr    = $expressionSolver->getConstExpression();
         }
 
-        if ($this->hasType()) {
+        if ($this->hasType() && $this->propertyOrPromotedParam->type !== null) {
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->hasDefaultValue() && $this->getDefaultValue() === null;
 
@@ -569,11 +569,13 @@ final class ReflectionProperty extends BaseReflectionProperty
     /** @param class-string<object> $fullClassName */
     private static function createEnumValueProperty(Enum_ $classLikeNode, string $fullClassName): ReflectionProperty
     {
-        $valuePropertyNode = (new \PhpParser\Builder\Property('value'))
+        $propertyBuilder = (new \PhpParser\Builder\Property('value'))
             ->makeReadonly()
-            ->makePublic()
-            ->setType($classLikeNode->scalarType)
-            ->getNode();
+            ->makePublic();
+        if ($classLikeNode->scalarType !== null) {
+            $propertyBuilder->setType($classLikeNode->scalarType);
+        }
+        $valuePropertyNode = $propertyBuilder->getNode();
 
         return new self(
             $fullClassName,

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -128,6 +128,14 @@ final class ReflectionProperty extends BaseReflectionProperty
     }
 
     /**
+     * Returns the AST node that contains attribute groups for this property.
+     */
+    protected function getNodeForAttributes(): Property|Param
+    {
+        return $this->propertyOrPromotedParam;
+    }
+
+    /**
      * Emulating original behaviour of reflection
      */
     public function __debugInfo(): array
@@ -496,7 +504,7 @@ final class ReflectionProperty extends BaseReflectionProperty
      * @param ClassLike            $classLikeNode Class-like node
      * @param class-string<object> $fullClassName FQN of the class
      *
-     * @return ReflectionProperty[]
+     * @return array<string, ReflectionProperty>
      */
     public static function collectFromClassNode(ClassLike $classLikeNode, string $fullClassName): array
     {

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -164,6 +164,8 @@ final class ReflectionProperty extends BaseReflectionProperty
 
     /**
      * {@inheritDoc}
+     *
+     * @return \ReflectionClass<object>
      */
     public function getDeclaringClass(): \ReflectionClass
     {

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -16,7 +16,6 @@ use Go\ParserReflection\Traits\InitializationTrait;
 use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use Go\ParserReflection\Resolver\TypeExpressionResolver;
-use JetBrains\PhpStorm\Deprecated;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\Node\PropertyItem;
@@ -31,11 +30,17 @@ use ReflectionProperty as BaseReflectionProperty;
  * AST-based reflection for class property
  * @see \Go\ParserReflection\ReflectionPropertyTest
  */
-class ReflectionProperty extends BaseReflectionProperty
+final class ReflectionProperty extends BaseReflectionProperty
 {
     use InitializationTrait;
     use InternalPropertiesEmulationTrait;
     use AttributeResolverTrait;
+
+    /**
+     * Re-declare to remove PHP 8.4 { get; } hooks so these properties can be unset in constructor
+     */
+    public string $name;
+    public string $class;
 
     private Property|Param $propertyOrPromotedParam;
 
@@ -53,8 +58,6 @@ class ReflectionProperty extends BaseReflectionProperty
     private bool $isDefaultValueConstant = false;
 
     private ?string $defaultValueConstantName;
-
-    private bool $isDefaultValueConstExpr = false;
 
     private ?string $defaultValueConstExpr;
 
@@ -87,7 +90,6 @@ class ReflectionProperty extends BaseReflectionProperty
             $this->defaultValue             = $expressionSolver->getValue();
             $this->isDefaultValueConstant   = $expressionSolver->isConstant();
             $this->defaultValueConstantName = $expressionSolver->getConstantName();
-            $this->isDefaultValueConstExpr  = $expressionSolver->isConstExpression();
             $this->defaultValueConstExpr    = $expressionSolver->getConstExpression();
         }
 
@@ -95,7 +97,7 @@ class ReflectionProperty extends BaseReflectionProperty
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->hasDefaultValue() && $this->getDefaultValue() === null;
 
-            $typeResolver = new TypeExpressionResolver($this->getDeclaringClass());
+            $typeResolver = new TypeExpressionResolver();
             $typeResolver->process($this->propertyOrPromotedParam->type, $hasDefaultNull);
 
             $this->type = $typeResolver->getType();
@@ -229,8 +231,7 @@ class ReflectionProperty extends BaseReflectionProperty
 
         return match (true) {
             $node instanceof PropertyItem => $node->name->toString(),
-            $node instanceof Param => (string) $node->var->name,
-            default => 'unknown'
+            default => (string) $node->var->name,
         };
     }
 
@@ -440,13 +441,27 @@ class ReflectionProperty extends BaseReflectionProperty
      */
     public function isVirtual(): bool
     {
-        return $this->propertyOrPromotedParam->isVirtual();
+        if (!$this->propertyOrPromotedParam instanceof Property) {
+            return false;
+        }
+        $hooks = $this->propertyOrPromotedParam->hooks;
+        if (empty($hooks)) {
+            return false;
+        }
+        // A property is virtual if it has hooks but none expose backing storage (byRef)
+        foreach ($hooks as $hook) {
+            if ($hook->byRef) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
      * {@inheritDoc}
      */
-    #[Deprecated(reason: 'This method is no-op starting from PHP 8.1', since: '8.1')]
+    #[\Deprecated('This method is no-op starting from PHP 8.1', since: '8.1')]
     public function setAccessible(bool $accessible): void
     {
     }
@@ -479,7 +494,7 @@ class ReflectionProperty extends BaseReflectionProperty
             if ($classLevelNode instanceof Property) {
                 foreach ($classLevelNode->props as $classPropertyNode) {
                     $propertyName = $classPropertyNode->name->toString();
-                    $properties[$propertyName] = new static(
+                    $properties[$propertyName] = new self(
                         $fullClassName,
                         $propertyName,
                         $classLevelNode,
@@ -493,7 +508,7 @@ class ReflectionProperty extends BaseReflectionProperty
                 foreach ($classLevelNode->getParams() as $paramNode) {
                     if ($paramNode->isPromoted()) {
                         $propertyName = (string) $paramNode->var->name;
-                        $properties[$propertyName] = new static(
+                        $properties[$propertyName] = new self(
                             $fullClassName,
                             $propertyName,
                             $paramNode,
@@ -532,7 +547,7 @@ class ReflectionProperty extends BaseReflectionProperty
             ->setType('string')
             ->getNode();
 
-        return new static(
+        return new self(
             $fullClassName,
             'name',
             $namePropertyNode,
@@ -548,7 +563,7 @@ class ReflectionProperty extends BaseReflectionProperty
             ->setType($classLikeNode->scalarType)
             ->getNode();
 
-        return new static(
+        return new self(
             $fullClassName,
             'value',
             $valuePropertyNode,

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -487,16 +487,11 @@ final class ReflectionProperty extends BaseReflectionProperty
     {
     }
 
-    /**
-     * @inheritDoc
-     *
-     * @param object|null $objectOrValue
-     */
     public function setValue(mixed $objectOrValue, mixed $value = null): void
     {
         $this->initializeInternalReflection();
 
-        if (!is_object($objectOrValue) && $objectOrValue !== null) {
+        if ($objectOrValue !== null && !is_object($objectOrValue)) {
             throw new \InvalidArgumentException('Expected object or null for $objectOrValue');
         }
         parent::setValue($objectOrValue, $value);

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -491,6 +491,13 @@ final class ReflectionProperty extends BaseReflectionProperty
     {
         $this->initializeInternalReflection();
 
+        if (func_num_args() < 2) {
+            // Single-argument form: sets a static property value (PHP 8.4+ canonical form).
+            parent::setValue(null, $objectOrValue);
+
+            return;
+        }
+
         if (!$this->isStatic() && $objectOrValue !== null && !is_object($objectOrValue)) {
             throw new \InvalidArgumentException('Expected object or null for $objectOrValue on non-static property');
         }

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -477,11 +477,16 @@ final class ReflectionProperty extends BaseReflectionProperty
 
     /**
      * @inheritDoc
+     *
+     * @param object|null $objectOrValue
      */
     public function setValue(mixed $objectOrValue, mixed $value = null): void
     {
         $this->initializeInternalReflection();
 
+        if (!is_object($objectOrValue) && $objectOrValue !== null) {
+            throw new \InvalidArgumentException('Expected object or null for $objectOrValue');
+        }
         parent::setValue($objectOrValue, $value);
     }
 

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -101,7 +101,11 @@ final class ReflectionProperty extends BaseReflectionProperty
             // If we have null value, this handled internally as nullable type too
             $hasDefaultNull = $this->hasDefaultValue() && $this->getDefaultValue() === null;
 
-            $typeResolver = new TypeExpressionResolver();
+            $declaringClass  = $this->getDeclaringClass();
+            $parentClass     = $declaringClass->getParentClass();
+            $parentClassName = ($parentClass !== false) ? $parentClass->getName() : null;
+
+            $typeResolver = new TypeExpressionResolver($this->className, $parentClassName);
             $typeResolver->process($this->propertyOrPromotedParam->type, $hasDefaultNull);
 
             $this->type = $typeResolver->getType();

--- a/src/ReflectionProperty.php
+++ b/src/ReflectionProperty.php
@@ -16,6 +16,7 @@ use Go\ParserReflection\Traits\InitializationTrait;
 use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use Go\ParserReflection\Resolver\TypeExpressionResolver;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\Node\PropertyItem;
@@ -48,6 +49,8 @@ final class ReflectionProperty extends BaseReflectionProperty
 
     /**
      * Name of the class
+     *
+     * @var class-string<object>
      */
     private string $className;
 
@@ -64,6 +67,7 @@ final class ReflectionProperty extends BaseReflectionProperty
     /**
      * Initializes a reflection for the property
      *
+     * @param class-string<object> $className
      * @param Property|Param|null $propertyOrPromotedParam Property type definition node
      * @param PropertyItem|Param|null $propertyItemOrPromotedParam Concrete property definition (value, name)
      * @throws ReflectionException
@@ -231,10 +235,13 @@ final class ReflectionProperty extends BaseReflectionProperty
     {
         $node = $this->propertyItemOrPromotedParam;
 
-        return match (true) {
-            $node instanceof PropertyItem => $node->name->toString(),
-            default => (string) $node->var->name,
-        };
+        if ($node instanceof PropertyItem) {
+            return $node->name->toString();
+        }
+        // $node is Param; var is Expr\Variable|Expr\Error; Expr\Variable->name is string|Expr
+        $varName = $node->var instanceof Expr\Variable ? $node->var->name : '';
+
+        return is_string($varName) ? $varName : '';
     }
 
     /**
@@ -398,7 +405,7 @@ final class ReflectionProperty extends BaseReflectionProperty
     public function isStatic(): bool
     {
         // All promoted properties are dynamic and not static
-        return !$this->isPromoted() && $this->propertyOrPromotedParam->isStatic();
+        return $this->propertyOrPromotedParam instanceof Property && $this->propertyOrPromotedParam->isStatic();
     }
 
     /**
@@ -481,8 +488,8 @@ final class ReflectionProperty extends BaseReflectionProperty
     /**
      * Parses properties from the concrete class node
      *
-     * @param ClassLike $classLikeNode Class-like node
-     * @param string    $fullClassName FQN of the class
+     * @param ClassLike            $classLikeNode Class-like node
+     * @param class-string<object> $fullClassName FQN of the class
      *
      * @return ReflectionProperty[]
      */
@@ -509,7 +516,8 @@ final class ReflectionProperty extends BaseReflectionProperty
             if ($classLevelNode instanceof ClassMethod && $classLevelNode->name->toString() === '__construct') {
                 foreach ($classLevelNode->getParams() as $paramNode) {
                     if ($paramNode->isPromoted()) {
-                        $propertyName = (string) $paramNode->var->name;
+                        $varName = $paramNode->var instanceof Expr\Variable ? $paramNode->var->name : '';
+                        $propertyName = is_string($varName) ? $varName : '';
                         $properties[$propertyName] = new self(
                             $fullClassName,
                             $propertyName,
@@ -541,6 +549,7 @@ final class ReflectionProperty extends BaseReflectionProperty
         parent::__construct($this->className, $this->getName());
     }
 
+    /** @param class-string<object> $fullClassName */
     private static function createEnumNameProperty(string $fullClassName): ReflectionProperty
     {
         $namePropertyNode = (new \PhpParser\Builder\Property('name'))
@@ -557,6 +566,7 @@ final class ReflectionProperty extends BaseReflectionProperty
         );
     }
 
+    /** @param class-string<object> $fullClassName */
     private static function createEnumValueProperty(Enum_ $classLikeNode, string $fullClassName): ReflectionProperty
     {
         $valuePropertyNode = (new \PhpParser\Builder\Property('value'))

--- a/src/ReflectionUnionType.php
+++ b/src/ReflectionUnionType.php
@@ -81,8 +81,8 @@ class ReflectionUnionType extends BaseReflectionUnionType
         }
 
         // PHP has own scheme of ordering of built-in types to follow
-        usort($stringTypes, function(string $first, string $second): int {
-            static $internalTypesOrder = ['object', 'array', 'string', 'int', 'float', 'bool', 'false', 'null'];
+        $internalTypesOrder = ['object', 'array', 'string', 'int', 'float', 'bool', 'false', 'null'];
+        usort($stringTypes, function(string $first, string $second) use ($internalTypesOrder): int {
 
             $firstOrder  = array_search($first, $internalTypesOrder, true);
             $secondOrder = array_search($second, $internalTypesOrder, true);

--- a/src/ReflectionUnionType.php
+++ b/src/ReflectionUnionType.php
@@ -90,10 +90,10 @@ class ReflectionUnionType extends BaseReflectionUnionType
             if ($firstOrder !== false && $secondOrder !== false) {
                 return $firstOrder <=> $secondOrder;
             }
-            if ($firstOrder !== false && $secondOrder === false) {
+            if ($firstOrder !== false) {
                 return 1;
             }
-            if ($firstOrder === false && $secondOrder !== false) {
+            if ($secondOrder !== false) {
                 return -1;
             }
 

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -123,7 +123,10 @@ class NodeExpressionResolver
                 $constantNodeName = $node->name;
                 // Unpack fully-resolved name if we have it inside attribute
                 if ($constantNodeName->hasAttribute('resolvedName')) {
-                    $constantNodeName = $constantNodeName->getAttribute('resolvedName');
+                    $resolvedName = $constantNodeName->getAttribute('resolvedName');
+                    if ($resolvedName instanceof Name) {
+                        $constantNodeName = $resolvedName;
+                    }
                 }
                 if ($constantNodeName->isFullyQualified()) {
                     // For full-qualified names we would like to remove leading "\"
@@ -203,7 +206,10 @@ class NodeExpressionResolver
     private function resolveName(Name $node): string
     {
         if ($node->hasAttribute('resolvedName')) {
-            return $node->getAttribute('resolvedName')->toString();
+            $resolvedName = $node->getAttribute('resolvedName');
+            if ($resolvedName instanceof Name) {
+                return $resolvedName->toString();
+            }
         }
 
         return $node->toString();
@@ -229,6 +235,9 @@ class NodeExpressionResolver
             // if function uses named arguments, then unpack argument name first
             if (isset($argumentNode->name)) {
                 $name = $this->resolve($argumentNode->name);
+                if (!is_string($name) && !is_int($name)) {
+                    continue;
+                }
                 $resolvedArgs[$name] = $value;
             } else {
                 // otherwise simply add argument to the list
@@ -236,6 +245,9 @@ class NodeExpressionResolver
             }
         }
 
+        if (!is_string($functionName) && !($functionName instanceof \Closure)) {
+            throw new ReflectionException("Could not resolve function name for function call.");
+        }
         $reflectedFunction = new \ReflectionFunction($functionName);
         if (!$reflectedFunction->isInternal()) {
             throw new ReflectionException("Only internal PHP functions can be evaluated safely");
@@ -256,7 +268,10 @@ class NodeExpressionResolver
         if ($classToInstantiateNode instanceof Node\Name) {
             // Unwrap resolved class name if we have it inside attributes
             if ($classToInstantiateNode->hasAttribute('resolvedName')) {
-                $classToInstantiateNode = $classToInstantiateNode->getAttribute('resolvedName');
+                $resolvedName = $classToInstantiateNode->getAttribute('resolvedName');
+                if ($resolvedName instanceof Node\Name) {
+                    $classToInstantiateNode = $resolvedName;
+                }
             }
             $className = $classToInstantiateNode->toString();
         } else {
@@ -277,6 +292,9 @@ class NodeExpressionResolver
             // if constructor uses named arguments, then unpack argument name first
             if (isset($argumentNode->name)) {
                 $name = $this->resolve($argumentNode->name);
+                if (!is_string($name) && !is_int($name)) {
+                    continue;
+                }
                 $resolvedArgs[$name] = $value;
             } else {
                 // otherwise simply add argument to the list
@@ -285,6 +303,9 @@ class NodeExpressionResolver
         }
 
         // Use ReflectionClass to safely instantiate the class
+        if (!class_exists($className)) {
+            throw new ReflectionException("Class '{$className}' does not exist and cannot be instantiated.");
+        }
         $reflectionClass = new \ReflectionClass($className);
         return $reflectionClass->newInstance(...$resolvedArgs);
     }
@@ -408,7 +429,10 @@ class NodeExpressionResolver
         $nodeConstantName = $node->name;
         // If we have resolved type name
         if ($nodeConstantName->hasAttribute('resolvedName')) {
-            $nodeConstantName = $nodeConstantName->getAttribute('resolvedName');
+            $resolvedConstantName = $nodeConstantName->getAttribute('resolvedName');
+            if ($resolvedConstantName instanceof Name) {
+                $nodeConstantName = $resolvedConstantName;
+            }
         }
         $isFQNConstant = $nodeConstantName instanceof Node\Name\FullyQualified;
         $constantName  = $nodeConstantName->toString();
@@ -455,7 +479,10 @@ class NodeExpressionResolver
         }
         // Unwrap resolved class name if we have it inside attributes
         if ($classToReflectNodeName->hasAttribute('resolvedName')) {
-            $classToReflectNodeName = $classToReflectNodeName->getAttribute('resolvedName');
+            $resolvedClassName = $classToReflectNodeName->getAttribute('resolvedName');
+            if ($resolvedClassName instanceof Node\Name) {
+                $classToReflectNodeName = $resolvedClassName;
+            }
         }
         $refClass = $this->fetchReflectionClass($classToReflectNodeName);
         if ($refClass === false) {
@@ -464,12 +491,15 @@ class NodeExpressionResolver
         if ($node->name instanceof Expr\Error) {
             $constantName = '';
         } elseif ($node->name instanceof Node\Identifier) {
-            $constantName = match (true) {
-                $node->name->hasAttribute('resolvedName') => $node->name->getAttribute('resolvedName')->toString(),
-                default => $node->name->toString(),
-            };
+            if ($node->name->hasAttribute('resolvedName')) {
+                $resolvedNodeName = $node->name->getAttribute('resolvedName');
+                $constantName = $resolvedNodeName instanceof Node\Name ? $resolvedNodeName->toString() : $node->name->toString();
+            } else {
+                $constantName = $node->name->toString();
+            }
         } else {
-            $constantName = (string) $this->resolve($node->name);
+            $resolvedName = $this->resolve($node->name);
+            $constantName = is_string($resolvedName) ? $resolvedName : '';
         }
 
         // special handling of ::class constants
@@ -479,7 +509,7 @@ class NodeExpressionResolver
 
         $this->isConstant   = true;
         $this->isConstExpr  = true;
-        $this->constantName = $classToReflectNodeName . '::' . $constantName;
+        $this->constantName = $classToReflectNodeName->toString() . '::' . $constantName;
 
         return $refClass->getConstant($constantName);
     }
@@ -494,8 +524,15 @@ class NodeExpressionResolver
 
         $result = [];
         foreach ($node->items as $itemIndex => $arrayItem) {
-            $itemValue        = $this->resolve($arrayItem->value);
-            $itemKey          = isset($arrayItem->key) ? $this->resolve($arrayItem->key) : $itemIndex;
+            $itemValue = $this->resolve($arrayItem->value);
+            if (isset($arrayItem->key)) {
+                $itemKey = $this->resolve($arrayItem->key);
+                if (!is_string($itemKey) && !is_int($itemKey)) {
+                    continue;
+                }
+            } else {
+                $itemKey = $itemIndex;
+            }
             $result[$itemKey] = $itemValue;
         }
 
@@ -507,27 +544,33 @@ class NodeExpressionResolver
      */
     protected function resolveExprBinaryOpPlus(Expr\BinaryOp\Plus $node): int|float|array
     {
-        return $this->resolve($node->left) + $this->resolve($node->right);
+        $left  = $this->resolve($node->left);
+        $right = $this->resolve($node->right);
+        if (is_array($left) && is_array($right)) {
+            return $left + $right;
+        }
+
+        return $this->resolveNumeric($left) + $this->resolveNumeric($right);
     }
 
     protected function resolveExprBinaryOpMinus(Expr\BinaryOp\Minus $node): int|float
     {
-        return $this->resolve($node->left) - $this->resolve($node->right);
+        return $this->resolveNumeric($this->resolve($node->left)) - $this->resolveNumeric($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpMul(Expr\BinaryOp\Mul $node): int|float
     {
-        return $this->resolve($node->left) * $this->resolve($node->right);
+        return $this->resolveNumeric($this->resolve($node->left)) * $this->resolveNumeric($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpPow(Expr\BinaryOp\Pow $node): int|float
     {
-        return $this->resolve($node->left) ** $this->resolve($node->right);
+        return $this->resolveNumeric($this->resolve($node->left)) ** $this->resolveNumeric($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpDiv(Expr\BinaryOp\Div $node): int|float
     {
-        return $this->resolve($node->left) / $this->resolve($node->right);
+        return $this->resolveNumeric($this->resolve($node->left)) / $this->resolveNumeric($this->resolve($node->right));
     }
 
     /**
@@ -537,7 +580,7 @@ class NodeExpressionResolver
      */
     protected function resolveExprBinaryOpMod(Expr\BinaryOp\Mod $node): int
     {
-        return $this->resolve($node->left) % $this->resolve($node->right);
+        return $this->resolveInt($this->resolve($node->left)) % $this->resolveInt($this->resolve($node->right));
     }
 
     protected function resolveExprBooleanNot(Expr\BooleanNot $node): bool
@@ -547,37 +590,45 @@ class NodeExpressionResolver
 
     protected function resolveExprBitwiseNot(Expr\BitwiseNot $node): int|string
     {
-        return ~$this->resolve($node->expr);
+        $value = $this->resolve($node->expr);
+        if (is_string($value)) {
+            return ~$value;
+        }
+
+        return ~$this->resolveInt($value);
     }
 
     protected function resolveExprBinaryOpBitwiseOr(Expr\BinaryOp\BitwiseOr $node): int
     {
-        return $this->resolve($node->left) | $this->resolve($node->right);
+        return $this->resolveInt($this->resolve($node->left)) | $this->resolveInt($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpBitwiseAnd(Expr\BinaryOp\BitwiseAnd $node): int
     {
-        return $this->resolve($node->left) & $this->resolve($node->right);
+        return $this->resolveInt($this->resolve($node->left)) & $this->resolveInt($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpBitwiseXor(Expr\BinaryOp\BitwiseXor $node): int
     {
-        return $this->resolve($node->left) ^ $this->resolve($node->right);
+        return $this->resolveInt($this->resolve($node->left)) ^ $this->resolveInt($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpShiftLeft(Expr\BinaryOp\ShiftLeft $node): int
     {
-        return $this->resolve($node->left) << $this->resolve($node->right);
+        return $this->resolveInt($this->resolve($node->left)) << $this->resolveInt($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpShiftRight(Expr\BinaryOp\ShiftRight $node): int
     {
-        return $this->resolve($node->left) >> $this->resolve($node->right);
+        return $this->resolveInt($this->resolve($node->left)) >> $this->resolveInt($this->resolve($node->right));
     }
 
     protected function resolveExprBinaryOpConcat(Expr\BinaryOp\Concat $node): string
     {
-        return $this->resolve($node->left) . $this->resolve($node->right);
+        $left  = $this->resolve($node->left);
+        $right = $this->resolve($node->right);
+
+        return (is_scalar($left) || $left === null ? (string) $left : '') . (is_scalar($right) || $right === null ? (string) $right : '');
     }
 
     protected function resolveExprTernary(Expr\Ternary $node): mixed
@@ -660,12 +711,39 @@ class NodeExpressionResolver
 
     protected function resolveExprUnaryMinus(Expr\UnaryMinus $node): int|float
     {
-        return -$this->resolve($node->expr);
+        return -$this->resolveNumeric($this->resolve($node->expr));
     }
 
     protected function resolveExprUnaryPlus(Expr\UnaryPlus $node): int|float
     {
-        return $this->resolve($node->expr);
+        return $this->resolveNumeric($this->resolve($node->expr));
+    }
+
+    private function resolveNumeric(mixed $value): int|float
+    {
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return strpos($value, '.') !== false ? (float) $value : (int) $value;
+        }
+        if (is_bool($value)) {
+            return $value ? 1 : 0;
+        }
+
+        return 0;
+    }
+
+    private function resolveInt(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_float($value) || is_string($value) || is_bool($value)) {
+            return (int) $value;
+        }
+
+        return 0;
     }
 
     private function getDispatchMethodFor(Node $node): string
@@ -693,7 +771,10 @@ class NodeExpressionResolver
     {
         // If we have already resolved node name, we should use it instead
         if ($node->hasAttribute('resolvedName')) {
-            $node = $node->getAttribute('resolvedName');
+            $resolvedNode = $node->getAttribute('resolvedName');
+            if ($resolvedNode instanceof Node\Name) {
+                $node = $resolvedNode;
+            }
         }
         $className  = $node->toString();
         $isFQNClass = $node instanceof Node\Name\FullyQualified;

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -39,6 +39,8 @@ class NodeExpressionResolver
 
     /**
      * List of exception for constant fetch
+     *
+     * @var array<string, bool>
      */
     private static array $notConstants = [
         'true'  => true,
@@ -48,6 +50,8 @@ class NodeExpressionResolver
 
     /**
      * Current reflection context for parsing
+     *
+     * @var \ReflectionClass<object>|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|\ReflectionParameter|\ReflectionAttribute<object>|\ReflectionProperty|ReflectionFileNamespace|null
      */
     private
         \ReflectionClass|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|
@@ -81,6 +85,9 @@ class NodeExpressionResolver
 
     private mixed $value;
 
+    /**
+     * @param \ReflectionClass<object>|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|\ReflectionParameter|\ReflectionAttribute<object>|\ReflectionProperty|ReflectionFileNamespace|null $context
+     */
     public function __construct($context)
     {
         $this->context = $context;
@@ -387,7 +394,7 @@ class NodeExpressionResolver
         return $this->context->name;
     }
 
-    protected function resolveExprConstFetch(Expr\ConstFetch $node)
+    protected function resolveExprConstFetch(Expr\ConstFetch $node): mixed
     {
         $constantValue = null;
         $isResolved    = false;
@@ -428,7 +435,7 @@ class NodeExpressionResolver
         return $constantValue;
     }
 
-    protected function resolveExprClassConstFetch(Expr\ClassConstFetch $node)
+    protected function resolveExprClassConstFetch(Expr\ClassConstFetch $node): mixed
     {
         $classToReflectNodeName = $node->class;
         if (!($classToReflectNodeName instanceof Node\Name)) {
@@ -466,6 +473,9 @@ class NodeExpressionResolver
         return $refClass->getConstant($constantName);
     }
 
+    /**
+     * @return array<int|string, mixed>
+     */
     protected function resolveExprArray(Expr\Array_ $node): array
     {
         // For array expressions we would like to have pretty-printed output too
@@ -481,6 +491,9 @@ class NodeExpressionResolver
         return $result;
     }
 
+    /**
+     * @return int|float|array<int|string, mixed>
+     */
     protected function resolveExprBinaryOpPlus(Expr\BinaryOp\Plus $node): int|float|array
     {
         return $this->resolve($node->left) + $this->resolve($node->right);
@@ -661,7 +674,7 @@ class NodeExpressionResolver
      *
      * @param Node\Name $node Class name node
      *
-     * @return bool|\ReflectionClass
+     * @return \ReflectionClass<object>|false
      *
      * @throws ReflectionException
      */

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -336,7 +336,7 @@ class NodeExpressionResolver
         if ($this->context instanceof ReflectionFileNamespace) {
             return $this->context->getName();
         }
-        if (!method_exists($this->context, 'getNamespaceName')) {
+        if ($this->context === null || !method_exists($this->context, 'getNamespaceName')) {
             throw new ReflectionException("Could not resolve __NAMESPACE__ without having getNamespaceName");
         }
 
@@ -351,7 +351,7 @@ class NodeExpressionResolver
         if ($this->context instanceof \ReflectionClass) {
             return $this->context->name;
         }
-        if (!method_exists($this->context, 'getDeclaringClass')) {
+        if ($this->context === null || !method_exists($this->context, 'getDeclaringClass')) {
             throw new ReflectionException("Could not resolve __CLASS__ without having getDeclaringClass");
         }
         $declaringClass = $this->context->getDeclaringClass();
@@ -364,7 +364,7 @@ class NodeExpressionResolver
      */
     protected function resolveScalarMagicConstDir(): string
     {
-        if (!method_exists($this->context, 'getFileName')) {
+        if ($this->context === null || !method_exists($this->context, 'getFileName')) {
             throw new ReflectionException("Could not resolve __DIR__ without having getFileName");
         }
 
@@ -376,7 +376,7 @@ class NodeExpressionResolver
      */
     protected function resolveScalarMagicConstFile(): string
     {
-        if (!method_exists($this->context, 'getFileName')) {
+        if ($this->context === null || !method_exists($this->context, 'getFileName')) {
             throw new ReflectionException("Could not resolve __FILE__ without having getFileName");
         }
 
@@ -413,7 +413,7 @@ class NodeExpressionResolver
         $isFQNConstant = $nodeConstantName instanceof Node\Name\FullyQualified;
         $constantName  = $nodeConstantName->toString();
 
-        if (!$isFQNConstant && method_exists($this->context, 'getFileName')) {
+        if (!$isFQNConstant && $this->context !== null && method_exists($this->context, 'getFileName')) {
             $fileName      = $this->context->getFileName();
             $namespaceName = $this->resolveScalarMagicConstNamespace();
             $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName);
@@ -427,7 +427,7 @@ class NodeExpressionResolver
         $isRealConstant = !isset(self::$notConstants[$constantName]);
         if (!$isResolved && defined($constantName)) {
             $constantValue = constant($constantName);
-            if (!$isFQNConstant && method_exists($this->context, 'getNamespaceName')) {
+            if (!$isFQNConstant && $this->context !== null && method_exists($this->context, 'getNamespaceName')) {
                 $constantName  = $this->context->getNamespaceName() . '\\' . $constantName;
             }
         }
@@ -715,7 +715,7 @@ class NodeExpressionResolver
                 return $this->context;
             }
 
-            if (method_exists($this->context, 'getDeclaringClass')) {
+            if ($this->context !== null && method_exists($this->context, 'getDeclaringClass')) {
                 return $this->context->getDeclaringClass();
             }
         }
@@ -725,14 +725,14 @@ class NodeExpressionResolver
                 return $this->context->getParentClass();
             }
 
-            if (method_exists($this->context, 'getDeclaringClass')) {
+            if ($this->context !== null && method_exists($this->context, 'getDeclaringClass')) {
                 return $this->context->getDeclaringClass()
                                      ->getParentClass()
                     ;
             }
         }
 
-        if (method_exists($this->context, 'getFileName')) {
+        if ($this->context !== null && method_exists($this->context, 'getFileName')) {
             $fileName      = $this->context->getFileName();
             $namespaceName = $this->resolveScalarMagicConstNamespace();
 

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -15,9 +15,7 @@ namespace Go\ParserReflection\Resolver;
 use Go\ParserReflection\ReflectionClass;
 use Go\ParserReflection\ReflectionException;
 use Go\ParserReflection\ReflectionFileNamespace;
-use Go\ParserReflection\ReflectionNamedType;
 use PhpParser\Node;
-use PhpParser\Node\Const_;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
@@ -229,14 +227,14 @@ class NodeExpressionResolver
         $resolvedArgs = [];
         foreach ($node->args as $argumentNode) {
             if (!$argumentNode instanceof Node\Arg) {
-                continue;
+                throw new ReflectionException('Cannot statically resolve a variadic placeholder argument in a function call');
             }
             $value = $this->resolve($argumentNode->value);
             // if function uses named arguments, then unpack argument name first
             if (isset($argumentNode->name)) {
                 $name = $this->resolve($argumentNode->name);
                 if (!is_string($name) && !is_int($name)) {
-                    continue;
+                    throw new ReflectionException(sprintf('Named argument key must be string or int, got %s', gettype($name)));
                 }
                 $resolvedArgs[$name] = $value;
             } else {
@@ -286,14 +284,14 @@ class NodeExpressionResolver
         $resolvedArgs = [];
         foreach ($node->args as $argumentNode) {
             if (!$argumentNode instanceof Node\Arg) {
-                continue;
+                throw new ReflectionException('Cannot statically resolve a variadic placeholder argument in a constructor call');
             }
             $value = $this->resolve($argumentNode->value);
             // if constructor uses named arguments, then unpack argument name first
             if (isset($argumentNode->name)) {
                 $name = $this->resolve($argumentNode->name);
                 if (!is_string($name) && !is_int($name)) {
-                    continue;
+                    throw new ReflectionException(sprintf('Named argument key must be string or int, got %s', gettype($name)));
                 }
                 $resolvedArgs[$name] = $value;
             } else {
@@ -550,7 +548,7 @@ class NodeExpressionResolver
             if (isset($arrayItem->key)) {
                 $itemKey = $this->resolve($arrayItem->key);
                 if (!is_string($itemKey) && !is_int($itemKey)) {
-                    continue;
+                    throw new ReflectionException(sprintf('Array key must be string or int, got %s', gettype($itemKey)));
                 }
             } else {
                 $itemKey = $itemIndex;

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -130,8 +130,10 @@ class NodeExpressionResolver
             if ($node instanceof Expr\Array_ && $node->getAttribute('kind') === Expr\Array_::KIND_LONG) {
                 $node->setAttribute('kind', Expr\Array_::KIND_SHORT);
             }
-            $printer    = new Standard(['shortArraySyntax' => true]);
-            $expression = $printer->prettyPrintExpr($node);
+            if ($node instanceof Expr) {
+                $printer    = new Standard(['shortArraySyntax' => true]);
+                $expression = $printer->prettyPrintExpr($node);
+            }
         }
 
         return $expression;
@@ -707,7 +709,6 @@ class NodeExpressionResolver
         }
 
         if (method_exists($this->context, 'getFileName')) {
-            /** @var ReflectionFileNamespace|null $fileNamespace */
             $fileName      = $this->context->getFileName();
             $namespaceName = $this->resolveScalarMagicConstNamespace();
 

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -357,7 +357,10 @@ class NodeExpressionResolver
         if ($this->context instanceof ReflectionFileNamespace) {
             return $this->context->getName();
         }
-        if ($this->context === null || !method_exists($this->context, 'getNamespaceName')) {
+        if (!($this->context instanceof \ReflectionClass
+            || $this->context instanceof \ReflectionFunction
+            || $this->context instanceof \ReflectionMethod
+        )) {
             throw new ReflectionException("Could not resolve __NAMESPACE__ without having getNamespaceName");
         }
 
@@ -376,6 +379,9 @@ class NodeExpressionResolver
             throw new ReflectionException("Could not resolve __CLASS__ without having getDeclaringClass");
         }
         $declaringClass = $this->context->getDeclaringClass();
+        if (!$declaringClass instanceof \ReflectionClass) {
+            throw new ReflectionException("Could not resolve __CLASS__: getDeclaringClass() did not return a ReflectionClass");
+        }
 
         return $declaringClass->name;
     }
@@ -385,11 +391,16 @@ class NodeExpressionResolver
      */
     protected function resolveScalarMagicConstDir(): string
     {
-        if ($this->context === null || !method_exists($this->context, 'getFileName')) {
+        if (!($this->context instanceof \ReflectionClass
+            || $this->context instanceof \ReflectionFunction
+            || $this->context instanceof \ReflectionMethod
+            || $this->context instanceof ReflectionFileNamespace
+        )) {
             throw new ReflectionException("Could not resolve __DIR__ without having getFileName");
         }
+        $fileName = $this->context->getFileName();
 
-        return dirname($this->context->getFileName());
+        return dirname((string) $fileName);
     }
 
     /**
@@ -397,11 +408,15 @@ class NodeExpressionResolver
      */
     protected function resolveScalarMagicConstFile(): string
     {
-        if ($this->context === null || !method_exists($this->context, 'getFileName')) {
+        if (!($this->context instanceof \ReflectionClass
+            || $this->context instanceof \ReflectionFunction
+            || $this->context instanceof \ReflectionMethod
+            || $this->context instanceof ReflectionFileNamespace
+        )) {
             throw new ReflectionException("Could not resolve __FILE__ without having getFileName");
         }
 
-        return $this->context->getFileName();
+        return (string) $this->context->getFileName();
     }
 
     protected function resolveScalarMagicConstLine(Line $node): int
@@ -437,8 +452,12 @@ class NodeExpressionResolver
         $isFQNConstant = $nodeConstantName instanceof Node\Name\FullyQualified;
         $constantName  = $nodeConstantName->toString();
 
-        if (!$isFQNConstant && $this->context !== null && method_exists($this->context, 'getFileName')) {
-            $fileName      = $this->context->getFileName();
+        if (!$isFQNConstant && ($this->context instanceof \ReflectionClass
+            || $this->context instanceof \ReflectionFunction
+            || $this->context instanceof \ReflectionMethod
+            || $this->context instanceof ReflectionFileNamespace
+        )) {
+            $fileName      = (string) $this->context->getFileName();
             $namespaceName = $this->resolveScalarMagicConstNamespace();
             $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName);
             if ($fileNamespace->hasConstant($constantName)) {
@@ -451,7 +470,10 @@ class NodeExpressionResolver
         $isRealConstant = !isset(self::$notConstants[$constantName]);
         if (!$isResolved && defined($constantName)) {
             $constantValue = constant($constantName);
-            if (!$isFQNConstant && $this->context !== null && method_exists($this->context, 'getNamespaceName')) {
+            if (!$isFQNConstant && ($this->context instanceof \ReflectionClass
+                || $this->context instanceof \ReflectionFunction
+                || $this->context instanceof \ReflectionMethod
+            )) {
                 $constantName  = $this->context->getNamespaceName() . '\\' . $constantName;
             }
         }
@@ -796,8 +818,17 @@ class NodeExpressionResolver
                 return $this->context;
             }
 
-            if ($this->context !== null && method_exists($this->context, 'getDeclaringClass')) {
+            if ($this->context instanceof \ReflectionMethod
+                || $this->context instanceof \ReflectionProperty
+                || $this->context instanceof \ReflectionClassConstant
+            ) {
                 return $this->context->getDeclaringClass();
+            }
+
+            if ($this->context instanceof \ReflectionParameter) {
+                $declaringClass = $this->context->getDeclaringClass();
+
+                return $declaringClass ?? false;
             }
         }
 
@@ -806,15 +837,26 @@ class NodeExpressionResolver
                 return $this->context->getParentClass();
             }
 
-            if ($this->context !== null && method_exists($this->context, 'getDeclaringClass')) {
-                return $this->context->getDeclaringClass()
-                                     ->getParentClass()
-                    ;
+            if ($this->context instanceof \ReflectionMethod
+                || $this->context instanceof \ReflectionProperty
+                || $this->context instanceof \ReflectionClassConstant
+            ) {
+                return $this->context->getDeclaringClass()->getParentClass();
+            }
+
+            if ($this->context instanceof \ReflectionParameter) {
+                $declaringClass = $this->context->getDeclaringClass();
+
+                return $declaringClass !== null ? $declaringClass->getParentClass() : false;
             }
         }
 
-        if ($this->context !== null && method_exists($this->context, 'getFileName')) {
-            $fileName      = $this->context->getFileName();
+        if ($this->context instanceof \ReflectionClass
+            || $this->context instanceof \ReflectionFunction
+            || $this->context instanceof \ReflectionMethod
+            || $this->context instanceof ReflectionFileNamespace
+        ) {
+            $fileName      = (string) $this->context->getFileName();
             $namespaceName = $this->resolveScalarMagicConstNamespace();
 
             $fileNamespace = new ReflectionFileNamespace($fileName, $namespaceName);

--- a/src/Resolver/NodeExpressionResolver.php
+++ b/src/Resolver/NodeExpressionResolver.php
@@ -222,6 +222,9 @@ class NodeExpressionResolver
         $functionName = $this->resolve($node->name);
         $resolvedArgs = [];
         foreach ($node->args as $argumentNode) {
+            if (!$argumentNode instanceof Node\Arg) {
+                continue;
+            }
             $value = $this->resolve($argumentNode->value);
             // if function uses named arguments, then unpack argument name first
             if (isset($argumentNode->name)) {
@@ -267,6 +270,9 @@ class NodeExpressionResolver
         // Resolve constructor arguments
         $resolvedArgs = [];
         foreach ($node->args as $argumentNode) {
+            if (!$argumentNode instanceof Node\Arg) {
+                continue;
+            }
             $value = $this->resolve($argumentNode->value);
             // if constructor uses named arguments, then unpack argument name first
             if (isset($argumentNode->name)) {
@@ -421,7 +427,7 @@ class NodeExpressionResolver
         $isRealConstant = !isset(self::$notConstants[$constantName]);
         if (!$isResolved && defined($constantName)) {
             $constantValue = constant($constantName);
-            if (!$isFQNConstant) {
+            if (!$isFQNConstant && method_exists($this->context, 'getNamespaceName')) {
                 $constantName  = $this->context->getNamespaceName() . '\\' . $constantName;
             }
         }
@@ -452,13 +458,18 @@ class NodeExpressionResolver
             $classToReflectNodeName = $classToReflectNodeName->getAttribute('resolvedName');
         }
         $refClass = $this->fetchReflectionClass($classToReflectNodeName);
-        if (($node->name instanceof Expr\Error)) {
+        if ($refClass === false) {
+            throw new ReflectionException("Could not resolve class for class constant fetch.");
+        }
+        if ($node->name instanceof Expr\Error) {
             $constantName = '';
-        } else {
+        } elseif ($node->name instanceof Node\Identifier) {
             $constantName = match (true) {
                 $node->name->hasAttribute('resolvedName') => $node->name->getAttribute('resolvedName')->toString(),
                 default => $node->name->toString(),
             };
+        } else {
+            $constantName = (string) $this->resolve($node->name);
         }
 
         // special handling of ::class constants

--- a/src/Resolver/TypeExpressionResolver.php
+++ b/src/Resolver/TypeExpressionResolver.php
@@ -53,8 +53,10 @@ class TypeExpressionResolver
 
     private \ReflectionNamedType|\ReflectionUnionType|\ReflectionIntersectionType|null $type;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly ?string $selfClassName = null,
+        private readonly ?string $parentClassName = null,
+    ) {
     }
 
     /**
@@ -152,7 +154,17 @@ class TypeExpressionResolver
             }
         }
 
-        return new ReflectionNamedType($node->toString(), $this->hasDefaultNull, false);
+        $typeName = $node->toString();
+
+        // Resolve self/parent to the actual class names when context is available.
+        // 'static' is intentionally kept as-is (late static binding, preserved by native reflection).
+        if ($typeName === 'self') {
+            $typeName = $this->selfClassName ?? $typeName;
+        } elseif ($typeName === 'parent') {
+            $typeName = $this->parentClassName ?? $typeName;
+        }
+
+        return new ReflectionNamedType($typeName, $this->hasDefaultNull, false);
     }
 
     private function resolveNameFullyQualified(Name\FullyQualified $node): ReflectionNamedType

--- a/src/Resolver/TypeExpressionResolver.php
+++ b/src/Resolver/TypeExpressionResolver.php
@@ -156,12 +156,15 @@ class TypeExpressionResolver
 
         $typeName = $node->toString();
 
-        // Resolve self/parent to the actual class names when context is available.
-        // 'static' is intentionally kept as-is (late static binding, preserved by native reflection).
-        if ($typeName === 'self') {
-            $typeName = $this->selfClassName ?? $typeName;
-        } elseif ($typeName === 'parent') {
-            $typeName = $this->parentClassName ?? $typeName;
+        // PHP 8.5+ changed ReflectionNamedType::getName() to return the actual FQCN for 'self'
+        // and 'parent', whereas PHP 8.4 and earlier preserve the keywords as-is.
+        // 'static' is always kept as-is (late static binding, preserved by native reflection).
+        if (PHP_VERSION_ID >= 80500) {
+            if ($typeName === 'self') {
+                $typeName = $this->selfClassName ?? $typeName;
+            } elseif ($typeName === 'parent') {
+                $typeName = $this->parentClassName ?? $typeName;
+            }
         }
 
         return new ReflectionNamedType($typeName, $this->hasDefaultNull, false);

--- a/src/Resolver/TypeExpressionResolver.php
+++ b/src/Resolver/TypeExpressionResolver.php
@@ -78,7 +78,7 @@ class TypeExpressionResolver
      *
      * @throws ReflectionException If couldn't resolve value for given Node
      */
-    final protected function resolve(Node $node): mixed
+    final protected function resolve(Node $node): ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType|null
     {
         $type = null;
         try {
@@ -89,7 +89,8 @@ class TypeExpressionResolver
             if (!method_exists($this, $methodName)) {
                 throw new ReflectionException("Could not find handler for the " . __CLASS__ . "::{$methodName} method");
             }
-            $type = $this->$methodName($node);
+            $resolvedType = $this->$methodName($node);
+            $type = ($resolvedType instanceof ReflectionNamedType || $resolvedType instanceof ReflectionUnionType || $resolvedType instanceof ReflectionIntersectionType) ? $resolvedType : null;
         } finally {
             array_pop($this->nodeStack);
             --$this->nodeLevel;
@@ -100,20 +101,28 @@ class TypeExpressionResolver
 
     private function resolveUnionType(Node\UnionType $unionType): ReflectionUnionType
     {
-        $resolvedTypes = array_map(
-            fn(Identifier|IntersectionType|Name $singleType) => $this->resolve($singleType),
-            $unionType->types
-        );
+        /** @var list<ReflectionIntersectionType|ReflectionNamedType> $resolvedTypes */
+        $resolvedTypes = [];
+        foreach ($unionType->types as $singleType) {
+            $resolved = $this->resolve($singleType);
+            if ($resolved instanceof ReflectionIntersectionType || $resolved instanceof ReflectionNamedType) {
+                $resolvedTypes[] = $resolved;
+            }
+        }
 
         return new ReflectionUnionType(...$resolvedTypes);
     }
 
     private function resolveIntersectionType(Node\IntersectionType $intersectionType): ReflectionIntersectionType
     {
-        $resolvedTypes = array_map(
-            fn(Identifier|IntersectionType|Name $singleType) => $this->resolve($singleType),
-            $intersectionType->types
-        );
+        /** @var list<ReflectionNamedType> $resolvedTypes */
+        $resolvedTypes = [];
+        foreach ($intersectionType->types as $singleType) {
+            $resolved = $this->resolve($singleType);
+            if ($resolved instanceof ReflectionNamedType) {
+                $resolvedTypes[] = $resolved;
+            }
+        }
 
         return new ReflectionIntersectionType(...$resolvedTypes);
     }
@@ -121,8 +130,9 @@ class TypeExpressionResolver
     private function resolveNullableType(Node\NullableType $node): ReflectionNamedType
     {
         $type = $this->resolve($node->type);
+        $typeName = $type instanceof ReflectionNamedType ? $type->getName() : '';
 
-        return new ReflectionNamedType($type->getName(), true, false);
+        return new ReflectionNamedType($typeName, true, false);
     }
 
     private function resolveIdentifier(Node\Identifier $node): ReflectionNamedType
@@ -136,7 +146,10 @@ class TypeExpressionResolver
     private function resolveName(Name $node): ReflectionNamedType
     {
         if ($node->hasAttribute('resolvedName')) {
-            $node = $node->getAttribute('resolvedName');
+            $resolvedNode = $node->getAttribute('resolvedName');
+            if ($resolvedNode instanceof Name) {
+                $node = $resolvedNode;
+            }
         }
 
         return new ReflectionNamedType($node->toString(), $this->hasDefaultNull, false);

--- a/src/Resolver/TypeExpressionResolver.php
+++ b/src/Resolver/TypeExpressionResolver.php
@@ -37,13 +37,6 @@ class TypeExpressionResolver
 {
 
     /**
-     * Current reflection context for parsing
-     */
-    private
-        \ReflectionClass|\ReflectionFunction|\ReflectionMethod|\ReflectionClassConstant|
-        \ReflectionParameter|\ReflectionAttribute|\ReflectionProperty|ReflectionFileNamespace|null $context;
-
-    /**
      * Whether this type has explicit null value set
      */
     private bool $hasDefaultNull = false;
@@ -60,9 +53,8 @@ class TypeExpressionResolver
 
     private \ReflectionNamedType|\ReflectionUnionType|\ReflectionIntersectionType|null $type;
 
-    public function __construct($context)
+    public function __construct()
     {
-        $this->context = $context;
     }
 
     /**

--- a/src/Traits/AttributeResolverTrait.php
+++ b/src/Traits/AttributeResolverTrait.php
@@ -15,10 +15,12 @@ namespace Go\ParserReflection\Traits;
 use Go\ParserReflection\ReflectionAttribute;
 use Go\ParserReflection\ReflectionProperty;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
+use PhpParser\Node\Name;
 
 trait AttributeResolverTrait
 {
     /**
+     * @param class-string<object>|null $name
      * @return ReflectionAttribute[]
      */
     public function getAttributes(?string $name = null, int $flags = 0): array
@@ -45,13 +47,14 @@ trait AttributeResolverTrait
                 if ($attributeNameNode->hasAttribute('resolvedName')) {
                     $attributeNameNode = $attributeNameNode->getAttribute('resolvedName');
                 }
+                $resolvedAttrName = self::resolveAttributeClassName($attributeNameNode);
                 if ($name === null) {
-                    $attributes[] = new ReflectionAttribute($attributeNameNode->toString(), $this, $arguments, $this->isAttributeRepeated($attributeNameNode->toString(), $node->attrGroups));
+                    $attributes[] = new ReflectionAttribute($resolvedAttrName, $this, $arguments, $this->isAttributeRepeated($resolvedAttrName, $node->attrGroups));
 
                     continue;
                 }
 
-                if ($name !== $attributeNameNode->toString()) {
+                if ($name !== $resolvedAttrName) {
                     continue;
                 }
 
@@ -60,6 +63,38 @@ trait AttributeResolverTrait
         }
 
         return $attributes;
+    }
+
+    /**
+     * Resolves the attribute class name from a Name node, returning it as a class-string.
+     *
+     * Attribute names in PHP are always class names. This method attempts to load the class
+     * via autoloading so PHPStan can narrow the type. For classes that cannot be autoloaded
+     * (e.g., optional dependency attributes), a cache entry is used.
+     *
+     * @param mixed $nameNode
+     * @return class-string<object>
+     */
+    private static function resolveAttributeClassName(mixed $nameNode): string
+    {
+        $className = $nameNode instanceof Name ? $nameNode->toString() : (string) $nameNode;
+        $className = ltrim($className, '\\');
+        // Fast path: already loaded without autoloading
+        if (class_exists($className, false) || interface_exists($className, false) || trait_exists($className, false) || enum_exists($className, false)) {
+            return $className;
+        }
+        // Try with autoloading
+        if (class_exists($className) || interface_exists($className) || trait_exists($className) || enum_exists($className)) {
+            return $className;
+        }
+        // For optional/not-installed attribute classes (e.g. JetBrains PhpStorm attributes),
+        // register as stdClass alias so the type is narrowable by PHPStan via class_exists()
+        class_alias(\stdClass::class, $className);
+        $registeredName = $className;
+        if (class_exists($registeredName, false)) {
+            return $registeredName;
+        }
+        throw new \LogicException("class_alias failed unexpectedly for attribute class: $className");
     }
 
     /**

--- a/src/Traits/AttributeResolverTrait.php
+++ b/src/Traits/AttributeResolverTrait.php
@@ -62,6 +62,9 @@ trait AttributeResolverTrait
         return $attributes;
     }
 
+    /**
+     * @param \PhpParser\Node\AttributeGroup[] $attrGroups
+     */
     private function isAttributeRepeated(string $attributeName, array $attrGroups): bool
     {
         $count = 0;

--- a/src/Traits/AttributeResolverTrait.php
+++ b/src/Traits/AttributeResolverTrait.php
@@ -77,7 +77,7 @@ trait AttributeResolverTrait
      */
     private static function resolveAttributeClassName(mixed $nameNode): string
     {
-        $className = $nameNode instanceof Name ? $nameNode->toString() : (string) $nameNode;
+        $className = $nameNode instanceof Name ? $nameNode->toString() : (is_scalar($nameNode) ? (string) $nameNode : '');
         $className = ltrim($className, '\\');
         // Fast path: already loaded without autoloading
         if (class_exists($className, false) || interface_exists($className, false) || trait_exists($className, false) || enum_exists($className, false)) {
@@ -109,7 +109,10 @@ trait AttributeResolverTrait
                 $attributeNameNode = $attr->name;
                 // If we have resoled node name, then we should use it instead
                 if ($attributeNameNode->hasAttribute('resolvedName')) {
-                    $attributeNameNode = $attributeNameNode->getAttribute('resolvedName');
+                    $resolvedNameNode = $attributeNameNode->getAttribute('resolvedName');
+                    if ($resolvedNameNode instanceof Name) {
+                        $attributeNameNode = $resolvedNameNode;
+                    }
                 }
 
                 if ($attributeNameNode->toString() === $attributeName) {

--- a/src/Traits/AttributeResolverTrait.php
+++ b/src/Traits/AttributeResolverTrait.php
@@ -73,35 +73,25 @@ trait AttributeResolverTrait
     }
 
     /**
-     * Resolves the attribute class name from a Name node, returning it as a class-string.
-     *
-     * Attribute names in PHP are always class names. This method attempts to load the class
-     * via autoloading so PHPStan can narrow the type. For classes that cannot be autoloaded
-     * (e.g., optional dependency attributes), a cache entry is used.
+     * Normalizes an attribute class name from a Name node, without triggering autoloading
+     * or registering any class aliases, to keep reflection side-effect free.
      *
      * @param mixed $nameNode
      * @return class-string<object>
      */
     private static function resolveAttributeClassName(mixed $nameNode): string
     {
-        $className = $nameNode instanceof Name ? $nameNode->toString() : (is_scalar($nameNode) ? (string) $nameNode : '');
+        $className = $nameNode instanceof Name
+            ? $nameNode->toString()
+            : (is_scalar($nameNode) ? (string) $nameNode : '');
+
         $className = ltrim($className, '\\');
-        // Fast path: already loaded without autoloading
-        if (class_exists($className, false) || interface_exists($className, false) || trait_exists($className, false) || enum_exists($className, false)) {
-            return $className;
+
+        if ($className === '') {
+            throw new \LogicException('Unable to resolve attribute class name from node');
         }
-        // Try with autoloading
-        if (class_exists($className) || interface_exists($className) || trait_exists($className) || enum_exists($className)) {
-            return $className;
-        }
-        // For optional/not-installed attribute classes (e.g. JetBrains PhpStorm attributes),
-        // register as stdClass alias so the type is narrowable by PHPStan via class_exists()
-        class_alias(\stdClass::class, $className);
-        $registeredName = $className;
-        if (class_exists($registeredName, false)) {
-            return $registeredName;
-        }
-        throw new \LogicException("class_alias failed unexpectedly for attribute class: $className");
+
+        return $className;
     }
 
     /**

--- a/src/Traits/AttributeResolverTrait.php
+++ b/src/Traits/AttributeResolverTrait.php
@@ -13,23 +13,30 @@ declare(strict_types=1);
 namespace Go\ParserReflection\Traits;
 
 use Go\ParserReflection\ReflectionAttribute;
-use Go\ParserReflection\ReflectionProperty;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\EnumCase;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Property;
 
 trait AttributeResolverTrait
 {
+    /**
+     * Returns the AST node that contains attribute groups for this reflection element.
+     */
+    abstract protected function getNodeForAttributes(): ClassLike|ClassMethod|Function_|Param|ClassConst|EnumCase|Property;
+
     /**
      * @param class-string<object>|null $name
      * @return ReflectionAttribute[]
      */
     public function getAttributes(?string $name = null, int $flags = 0): array
     {
-        if ($this instanceof ReflectionProperty) {
-            $node = $this->getTypeNode();
-        } else {
-            $node = $this->getNode();
-        }
+        $node = $this->getNodeForAttributes();
 
         $attributes = [];
         $nodeExpressionResolver = new NodeExpressionResolver($this);

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -209,7 +209,7 @@ trait ReflectionClassLikeTrait
     public function getConstant(string $name): mixed
     {
         if ($this->hasConstant($name)) {
-            return $this->constants[$name];
+            return $this->getConstants()[$name];
         }
 
         return false;

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -45,6 +45,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * Short name of the class, without namespace
+     *
+     * @var non-empty-string
      */
     protected string $className;
 
@@ -221,15 +223,33 @@ trait ReflectionClassLikeTrait
     public function getConstants(?int $filter = null): array
     {
         if (!isset($this->constants)) {
-            $this->constants = $this->recursiveCollect(
-                function (array &$result, \ReflectionClass $instance) {
-                    $result += $instance->getConstants();
-                }
-            );
+            $this->constants = $this->collectInheritedConstants();
             $this->collectSelfConstants();
         }
 
-        return $this->constants;
+        return $this->constants ?? [];
+    }
+
+    /**
+     * Collects constants from parent classes, traits, and interfaces.
+     *
+     * @return array<string, mixed>
+     */
+    private function collectInheritedConstants(): array
+    {
+        $result = [];
+        foreach ($this->getTraits() as $trait) {
+            $result += $trait->getConstants();
+        }
+        $parentClass = $this->getParentClass();
+        if ($parentClass !== false) {
+            $result += $parentClass->getConstants();
+        }
+        foreach (ReflectionClass::collectInterfacesFromClassNode($this->classLikeNode) as $interface) {
+            $result += $interface->getConstants();
+        }
+
+        return $result;
     }
 
     /**
@@ -437,12 +457,41 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return class-string<object>
      */
     public function getName(): string
     {
         $namespaceName = $this->namespaceName ? $this->namespaceName . '\\' : '';
+        $fullName = $namespaceName . $this->getShortName();
 
-        return $namespaceName . $this->getShortName();
+        return $this->resolveAsClassString($fullName);
+    }
+
+    /**
+     * Resolves a fully-qualified class name string as a class-string type.
+     * Classes reflected via AST may not be loaded yet; this method attempts autoloading
+     * and falls back to returning the name as-is (which is valid since class names ARE class-strings).
+     *
+     * @param non-empty-string $name
+     * @return class-string<object>
+     */
+    private function resolveAsClassString(string $name): string
+    {
+        if (class_exists($name, false) || interface_exists($name, false) || trait_exists($name, false) || enum_exists($name, false)) {
+            return $name;
+        }
+        // Trigger autoloading for the class - this resolves the type for PHPStan
+        if (class_exists($name) || interface_exists($name) || trait_exists($name) || enum_exists($name)) {
+            return $name;
+        }
+        // For AST-only classes not yet loadable, register as stdClass alias so PHPStan can narrow the type
+        class_alias(\stdClass::class, $name);
+        $registeredName = $name;
+        if (class_exists($registeredName, false)) {
+            return $registeredName;
+        }
+        throw new \LogicException("class_alias failed unexpectedly for class name: $name");
     }
 
     /**
@@ -579,6 +628,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return non-empty-string
      */
     public function getShortName(): string
     {

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -79,7 +79,7 @@ trait ReflectionClassLikeTrait
     protected array $traitAdaptations = [];
 
     /**
-     * @var ReflectionMethod[]
+     * @var array<string, \ReflectionMethod>|null
      */
     protected ?array $methods;
 
@@ -96,12 +96,12 @@ trait ReflectionClassLikeTrait
     protected null|\ReflectionClass|false $parentClass;
 
     /**
-     * @var ReflectionProperty[]
+     * @var array<string, \ReflectionProperty>|null
      */
     protected ?array $properties;
 
     /**
-     * @var ReflectionClassConstant[]
+     * @var array<string, \ReflectionClassConstant>|null
      */
     protected ?array $classConstants;
 
@@ -142,16 +142,18 @@ trait ReflectionClassLikeTrait
             }
         }
 
-        $buildString = static function (array $items, $indentLevel = 4) {
+        $buildString = static function (array $items, int $indentLevel = 4): string {
             if (!count($items)) {
                 return '';
             }
-            $indent = "\n" . str_repeat(' ', $indentLevel);
+            $indent  = "\n" . str_repeat(' ', $indentLevel);
+            $joined  = implode("\n", array_map('strval', array_filter($items, 'is_scalar')))
+                . implode("\n", array_map(static fn(\Stringable $item): string => (string) $item, array_filter($items, fn($item): bool => $item instanceof \Stringable)));
 
-            return $indent . implode($indent, explode("\n", implode("\n", $items)));
+            return $indent . implode($indent, explode("\n", $joined));
         };
 
-        $buildConstants = static function (array $items, $indentLevel = 4) {
+        $buildConstants = static function (array $items, int $indentLevel = 4): string {
             $str = '';
             foreach ($items as $name => $value) {
                 $str .= "\n" . str_repeat(' ', $indentLevel);
@@ -159,7 +161,7 @@ trait ReflectionClassLikeTrait
                     'Constant [ %s %s ] { %s }',
                     gettype($value),
                     $name,
-                    $value
+                    is_scalar($value) || $value === null ? $value : ''
                 );
             }
 
@@ -255,7 +257,7 @@ trait ReflectionClassLikeTrait
     /**
      * {@inheritDoc}
      */
-    public function getConstructor(): ?ReflectionMethod
+    public function getConstructor(): ?\ReflectionMethod
     {
         try {
             $constructor = $this->getMethod('__construct');
@@ -296,9 +298,12 @@ trait ReflectionClassLikeTrait
                     $defaultValues[$propertyName] = $property->getValue();
                 } elseif (!$isStaticProperty) {
                     // Internal reflection and dynamic property
-                    $classProperties = $property->getDeclaringClass()->getDefaultProperties();
+                    $declaringClass  = $property->getDeclaringClass();
+                    if ($declaringClass instanceof \ReflectionClass) {
+                        $classProperties = $declaringClass->getDefaultProperties();
 
-                    $defaultValues[$propertyName] = $classProperties[$propertyName];
+                        $defaultValues[$propertyName] = $classProperties[$propertyName];
+                    }
                 }
             }
         }
@@ -357,11 +362,13 @@ trait ReflectionClassLikeTrait
     {
         if (!isset($this->interfaceClasses)) {
             $this->interfaceClasses = $this->recursiveCollect(
-                function (array &$result, \ReflectionClass $instance) {
+                function (\ReflectionClass $instance, bool $isParent): array {
+                    $result = [];
                     if ($instance->isInterface()) {
                         $result[$instance->name] = $instance;
                     }
-                    $result += $instance->getInterfaces();
+
+                    return $result + $instance->getInterfaces();
                 }
             );
         }
@@ -371,8 +378,6 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritdoc}
-     *
-     * @return ReflectionMethod
      */
     public function getMethod(string $name): \ReflectionMethod
     {
@@ -388,21 +393,22 @@ trait ReflectionClassLikeTrait
     /**
      * {@inheritdoc}
      *
-     * @return ReflectionMethod[]
+     * @return \ReflectionMethod[]
      */
     public function getMethods(int|null $filter = null): array
     {
         if (!isset($this->methods)) {
             $directMethods = ReflectionMethod::collectFromClassNode($this->classLikeNode, $this);
             $parentMethods = $this->recursiveCollect(
-                function (array &$result, \ReflectionClass $instance, $isParent) {
+                function (\ReflectionClass $instance, bool $isParent): array {
                     $reflectionMethods = [];
                     foreach ($instance->getMethods() as $reflectionMethod) {
                         if (!$isParent || !$reflectionMethod->isPrivate()) {
                             $reflectionMethods[$reflectionMethod->name] = $reflectionMethod;
                         }
                     }
-                    $result += $reflectionMethods;
+
+                    return $reflectionMethods;
                 }
             );
             $methods = $directMethods + $parentMethods;
@@ -533,21 +539,22 @@ trait ReflectionClassLikeTrait
      *
      * @inheritDoc
      *
-     * @return ReflectionProperty[]
+     * @return \ReflectionProperty[]
      */
     public function getProperties(int|null $filter = null): array
     {
         if (!isset($this->properties)) {
             $directProperties = ReflectionProperty::collectFromClassNode($this->classLikeNode, $this->getName());
             $parentProperties = $this->recursiveCollect(
-                function (array &$result, \ReflectionClass $instance, $isParent) {
+                function (\ReflectionClass $instance, bool $isParent): array {
                     $reflectionProperties = [];
                     foreach ($instance->getProperties() as $reflectionProperty) {
                         if (!$isParent || !$reflectionProperty->isPrivate()) {
                             $reflectionProperties[$reflectionProperty->name] = $reflectionProperty;
                         }
                     }
-                    $result += $reflectionProperties;
+
+                    return $reflectionProperties;
                 }
             );
             $properties = $directProperties + $parentProperties;
@@ -612,14 +619,15 @@ trait ReflectionClassLikeTrait
                 $this->getName()
             );
             $parentClassConstants = $this->recursiveCollect(
-                function (array &$result, \ReflectionClass $instance, $isParent) {
+                function (\ReflectionClass $instance, bool $isParent): array {
                     $reflectionClassConstants = [];
                     foreach ($instance->getReflectionConstants() as $reflectionClassConstant) {
                         if (!$isParent || !$reflectionClassConstant->isPrivate()) {
                             $reflectionClassConstants[$reflectionClassConstant->name] = $reflectionClassConstant;
                         }
                     }
-                    $result += $reflectionClassConstants;
+
+                    return $reflectionClassConstants;
                 }
             );
             $classConstants = $directClassConstants + $parentClassConstants;
@@ -1046,7 +1054,7 @@ trait ReflectionClassLikeTrait
 
     /**
      * @template TValue
-     * @param \Closure(array<string, TValue>&, \ReflectionClass<object>, bool): void $collector
+     * @param \Closure(\ReflectionClass<object>, bool): array<string, TValue> $collector
      * @return array<string, TValue>
      */
     private function recursiveCollect(Closure $collector): array
@@ -1056,17 +1064,17 @@ trait ReflectionClassLikeTrait
 
         $traits = $this->getTraits();
         foreach ($traits as $trait) {
-            $collector($result, $trait, false);
+            $result += $collector($trait, false);
         }
 
         $parentClass = $this->getParentClass();
         if ($parentClass) {
-            $collector($result, $parentClass, $isParent);
+            $result += $collector($parentClass, $isParent);
         }
 
         $interfaces = ReflectionClass::collectInterfacesFromClassNode($this->classLikeNode);
         foreach ($interfaces as $interface) {
-            $collector($result, $interface, $isParent);
+            $result += $collector($interface, $isParent);
         }
 
         return $result;
@@ -1089,7 +1097,7 @@ trait ReflectionClassLikeTrait
                         $expressionSolver->process($nodeConstant->value);
                         $localConstants[$nodeConstant->name->toString()] = $expressionSolver->getValue();
 
-                        $this->constants = $localConstants + $this->constants;
+                        $this->constants = $localConstants + ($this->constants ?? []);
                     }
                 }
             }

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -299,11 +299,9 @@ trait ReflectionClassLikeTrait
                 } elseif (!$isStaticProperty) {
                     // Internal reflection and dynamic property
                     $declaringClass  = $property->getDeclaringClass();
-                    if ($declaringClass instanceof \ReflectionClass) {
-                        $classProperties = $declaringClass->getDefaultProperties();
+                    $classProperties = $declaringClass->getDefaultProperties();
 
-                        $defaultValues[$propertyName] = $classProperties[$propertyName];
-                    }
+                    $defaultValues[$propertyName] = $classProperties[$propertyName];
                 }
             }
         }

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -601,7 +601,7 @@ trait ReflectionClassLikeTrait
         $traits  = $this->getTraits();
         foreach ($this->traitAdaptations as $adaptation) {
             if ($adaptation instanceof TraitUseAdaptation\Alias) {
-                $methodName = $adaptation->method;
+                $methodName = (string) $adaptation->method;
                 $traitName  = null;
                 foreach ($traits as $trait) {
                     if ($trait->hasMethod($methodName)) {
@@ -609,7 +609,7 @@ trait ReflectionClassLikeTrait
                         break;
                     }
                 }
-                $aliases[$adaptation->newName] = $traitName . '::' . $methodName;
+                $aliases[(string) $adaptation->newName] = $traitName . '::' . $methodName;
             }
         }
 
@@ -978,7 +978,7 @@ trait ReflectionClassLikeTrait
 
         $traits = $this->getTraits();
         foreach ($traits as $trait) {
-            $collector($result, $trait, !$isParent);
+            $collector($result, $trait, false);
         }
 
         $parentClass = $this->getParentClass();

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -50,20 +50,22 @@ trait ReflectionClassLikeTrait
 
     /**
      * List of all constants from the class or null if not initialized yet
+     *
+     * @var array<string, mixed>|null
      */
     protected ?array $constants;
 
     /**
      * Interfaces or null if not initialized yet
      *
-     * @var \ReflectionClass[]|null
+     * @var \ReflectionClass<object>[]|null
      */
     protected ?array $interfaceClasses;
 
     /**
      * List of traits or null if not initialized yet
      *
-     * @var  \ReflectionClass[]|null
+     * @var \ReflectionClass<object>[]|null
      */
     protected ?array $traits;
 
@@ -86,6 +88,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * Parent class, or false if not present, null if uninitialized yet
+     *
+     * @var \ReflectionClass<object>|false|null
      */
     protected null|\ReflectionClass|false $parentClass;
 
@@ -211,6 +215,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return array<string, mixed>
      */
     public function getConstants(?int $filter = null): array
     {
@@ -245,7 +251,7 @@ trait ReflectionClassLikeTrait
      *
      * @link http://php.net/manual/en/reflectionclass.getdefaultproperties.php
      *
-     * @return array An array of default properties, with the key being the name of the property and the value being
+     * @return array<string, mixed> An array of default properties, with the key being the name of the property and the value being
      * the default value of the property or NULL if the property doesn't have a default value
      */
     public function getDefaultProperties(): array
@@ -320,6 +326,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return \ReflectionClass<object>[]
      */
     public function getInterfaces(): array
     {
@@ -447,6 +455,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return \ReflectionClass<object>|false
      */
     public function getParentClass(): \ReflectionClass|false
     {
@@ -592,7 +602,7 @@ trait ReflectionClassLikeTrait
      *
      * @link http://php.net/manual/en/reflectionclass.gettraitaliases.php
      *
-     * @return array an array with new method names in keys and original names (in the format
+     * @return array<string, string> an array with new method names in keys and original names (in the format
      *                    "TraitName::original") in values.
      */
     public function getTraitAliases(): array
@@ -631,7 +641,7 @@ trait ReflectionClassLikeTrait
      *
      * @link http://php.net/manual/en/reflectionclass.gettraits.php
      *
-     * @return \ReflectionClass[]
+     * @return \ReflectionClass<object>[]
      */
     public function getTraits(): array
     {
@@ -689,6 +699,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @param \ReflectionClass<object>|string $interfaceName
      */
     public function implementsInterface(\ReflectionClass|string $interfaceName): bool
     {
@@ -828,6 +840,8 @@ trait ReflectionClassLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @param \ReflectionClass<object>|string $class
      */
     public function isSubclassOf(\ReflectionClass|string $class): bool
     {
@@ -880,6 +894,8 @@ trait ReflectionClassLikeTrait
      * Gets static properties
      *
      * @link http://php.net/manual/en/reflectionclass.getstaticproperties.php
+     *
+     * @return array<string, mixed>
      */
     public function getStaticProperties(): array
     {
@@ -935,7 +951,7 @@ trait ReflectionClassLikeTrait
      *
      * @link http://php.net/manual/en/reflectionclass.newinstanceargs.php
      *
-     * @param array $args The parameters to be passed to the class constructor as an array.
+     * @param array<int, mixed> $args The parameters to be passed to the class constructor as an array.
      */
     public function newInstanceArgs(array $args = []): ?object
     {
@@ -971,6 +987,9 @@ trait ReflectionClassLikeTrait
         parent::setStaticPropertyValue($name, $value);
     }
 
+    /**
+     * @return array<string|int, mixed>
+     */
     private function recursiveCollect(Closure $collector): array
     {
         $result   = [];

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -318,7 +318,9 @@ trait ReflectionClassLikeTrait
 
     public function getEndLine(): int|false
     {
-        return $this->classLikeNode->getAttribute('endLine');
+        $endLine = $this->classLikeNode->getAttribute('endLine');
+
+        return is_int($endLine) ? $endLine : false;
     }
 
     public function getExtension(): ?ReflectionExtension
@@ -333,7 +335,9 @@ trait ReflectionClassLikeTrait
 
     public function getFileName(): string|false
     {
-        return $this->classLikeNode->getAttribute('fileName');
+        $fileName = $this->classLikeNode->getAttribute('fileName');
+
+        return is_string($fileName) ? $fileName : false;
     }
 
     /**
@@ -642,10 +646,12 @@ trait ReflectionClassLikeTrait
             $attrGroups = $this->classLikeNode->attrGroups;
             $lastAttrGroupsEndLine = end($attrGroups)->getAttribute('endLine');
 
-            return $lastAttrGroupsEndLine + 1;
+            return is_int($lastAttrGroupsEndLine) ? $lastAttrGroupsEndLine + 1 : false;
         }
 
-        return $this->classLikeNode->getAttribute('startLine');
+        $startLine = $this->classLikeNode->getAttribute('startLine');
+
+        return is_int($startLine) ? $startLine : false;
     }
 
     /**
@@ -1039,7 +1045,9 @@ trait ReflectionClassLikeTrait
     }
 
     /**
-     * @return array<string|int, mixed>
+     * @template TValue
+     * @param \Closure(array<string, TValue>&, \ReflectionClass<object>, bool): void $collector
+     * @return array<string, TValue>
      */
     private function recursiveCollect(Closure $collector): array
     {

--- a/src/Traits/ReflectionClassLikeTrait.php
+++ b/src/Traits/ReflectionClassLikeTrait.php
@@ -477,29 +477,16 @@ trait ReflectionClassLikeTrait
     }
 
     /**
-     * Resolves a fully-qualified class name string as a class-string type.
-     * Classes reflected via AST may not be loaded yet; this method attempts autoloading
-     * and falls back to returning the name as-is (which is valid since class names ARE class-strings).
+     * Returns a fully-qualified class name. The name is semantically a class-string (it comes
+     * from the AST of a PHP class declaration), but PHPStan cannot verify this without
+     * autoloading, which would violate the library's contract of reflecting without loading.
      *
      * @param non-empty-string $name
      * @return class-string<object>
      */
     private function resolveAsClassString(string $name): string
     {
-        if (class_exists($name, false) || interface_exists($name, false) || trait_exists($name, false) || enum_exists($name, false)) {
-            return $name;
-        }
-        // Trigger autoloading for the class - this resolves the type for PHPStan
-        if (class_exists($name) || interface_exists($name) || trait_exists($name) || enum_exists($name)) {
-            return $name;
-        }
-        // For AST-only classes not yet loadable, register as stdClass alias so PHPStan can narrow the type
-        class_alias(\stdClass::class, $name);
-        $registeredName = $name;
-        if (class_exists($registeredName, false)) {
-            return $registeredName;
-        }
-        throw new \LogicException("class_alias failed unexpectedly for class name: $name");
+        return $name;
     }
 
     /**

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -292,9 +292,7 @@ trait ReflectionFunctionLikeTrait
      */
     public function isInternal(): bool
     {
-        // never can be an internal method, except for the Enum magic methods
-        $isEnumMethod = $this instanceof ReflectionMethod && $this->getDeclaringClass()->isEnum();
-        return $isEnumMethod && in_array($this->getName(), ['cases', 'tryFrom', 'from']);
+        return false;
     }
 
     /**
@@ -302,9 +300,7 @@ trait ReflectionFunctionLikeTrait
      */
     public function isUserDefined(): bool
     {
-        // always user-defined method, except for the Enum magic methods
-        $isEnumMethod = $this instanceof ReflectionMethod && $this->getDeclaringClass()->isEnum();
-        return !($isEnumMethod && in_array($this->getName(), ['cases', 'tryFrom', 'from']));
+        return true;
     }
 
     /**

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -161,8 +161,6 @@ trait ReflectionFunctionLikeTrait
 
             foreach ($this->functionLikeNode->getParams() as $parameterIndex => $parameterNode) {
                 $reflectionParameter = new ReflectionParameter(
-                    $this->getName(),
-                    (string)$parameterNode->var->name,
                     $parameterNode,
                     $parameterIndex,
                     $this
@@ -185,7 +183,7 @@ trait ReflectionFunctionLikeTrait
     public function getReturnType(): \ReflectionNamedType|\ReflectionUnionType|\ReflectionIntersectionType|null
     {
         if ($this->hasReturnType()) {
-            $typeResolver = new TypeExpressionResolver($this);
+            $typeResolver = new TypeExpressionResolver();
             $typeResolver->process($this->functionLikeNode->getReturnType(), false);
 
             return $typeResolver->getType();
@@ -208,8 +206,8 @@ trait ReflectionFunctionLikeTrait
 
     public function getStartLine(): int|false
     {
-        if ($this->functionLikeNode->attrGroups !== []) {
-            $attrGroups = $this->functionLikeNode->attrGroups;
+        if ($this->functionLikeNode->getAttrGroups() !== []) {
+            $attrGroups = $this->functionLikeNode->getAttrGroups();
             $lastAttrGroupsEndLine = end($attrGroups)->getAttribute('endLine');
 
             return $lastAttrGroupsEndLine + 1;

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -78,11 +78,9 @@ trait ReflectionFunctionLikeTrait
 
     public function getEndLine(): int|false
     {
-        if ($this->functionLikeNode->hasAttribute('endLine')) {
-            return $this->functionLikeNode->getAttribute('endLine');
-        }
+        $endLine = $this->functionLikeNode->getAttribute('endLine');
 
-        return false;
+        return is_int($endLine) ? $endLine : false;
     }
 
     public function getExtension(): ?ReflectionExtension
@@ -97,11 +95,9 @@ trait ReflectionFunctionLikeTrait
 
     public function getFileName(): string|false
     {
-        if ($this->functionLikeNode->hasAttribute('fileName')) {
-            return $this->functionLikeNode->getAttribute('fileName');
-        }
+        $fileName = $this->functionLikeNode->getAttribute('fileName');
 
-        return false;
+        return is_string($fileName) ? $fileName : false;
     }
 
     /**
@@ -213,14 +209,12 @@ trait ReflectionFunctionLikeTrait
             $attrGroups = $this->functionLikeNode->getAttrGroups();
             $lastAttrGroupsEndLine = end($attrGroups)->getAttribute('endLine');
 
-            return $lastAttrGroupsEndLine + 1;
+            return is_int($lastAttrGroupsEndLine) ? $lastAttrGroupsEndLine + 1 : false;
         }
 
-        if ($this->functionLikeNode->hasAttribute('startLine')) {
-            return $this->functionLikeNode->getAttribute('startLine');
-        }
+        $startLine = $this->functionLikeNode->getAttribute('startLine');
 
-        return false;
+        return is_int($startLine) ? $startLine : false;
     }
 
     /**

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -49,6 +49,8 @@ trait ReflectionFunctionLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return \ReflectionClass<object>|null
      */
     public function getClosureScopeClass(): ?\ReflectionClass
     {
@@ -222,6 +224,8 @@ trait ReflectionFunctionLikeTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @return array<string, mixed>
      */
     public function getStaticVariables(): array
     {

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -184,9 +184,10 @@ trait ReflectionFunctionLikeTrait
      */
     public function getReturnType(): \ReflectionNamedType|\ReflectionUnionType|\ReflectionIntersectionType|null
     {
-        if ($this->hasReturnType()) {
+        $returnType = $this->functionLikeNode->getReturnType();
+        if ($this->hasReturnType() && $returnType !== null) {
             $typeResolver = new TypeExpressionResolver();
-            $typeResolver->process($this->functionLikeNode->getReturnType(), false);
+            $typeResolver->process($returnType, false);
 
             return $typeResolver->getType();
         }

--- a/src/Traits/ReflectionFunctionLikeTrait.php
+++ b/src/Traits/ReflectionFunctionLikeTrait.php
@@ -35,6 +35,24 @@ trait ReflectionFunctionLikeTrait
 {
     use InitializationTrait;
 
+    /**
+     * Returns the name of the class this function/method belongs to, for self/parent type resolution.
+     * Overridden in ReflectionMethod; returns null for standalone functions.
+     */
+    protected function getDeclaringClassNameForTypes(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Returns the parent class name for type resolution, or null if none.
+     * Overridden in ReflectionMethod; returns null for standalone functions.
+     */
+    protected function getParentClassNameForTypes(): ?string
+    {
+        return null;
+    }
+
     protected FunctionLike|Function_|ClassMethod $functionLikeNode;
 
     /**
@@ -182,7 +200,10 @@ trait ReflectionFunctionLikeTrait
     {
         $returnType = $this->functionLikeNode->getReturnType();
         if ($this->hasReturnType() && $returnType !== null) {
-            $typeResolver = new TypeExpressionResolver();
+            $selfClassName   = $this->getDeclaringClassNameForTypes();
+            $parentClassName = $this->getParentClassNameForTypes();
+
+            $typeResolver = new TypeExpressionResolver($selfClassName, $parentClassName);
             $typeResolver->process($returnType, false);
 
             return $typeResolver->getType();

--- a/tests/ReflectionParameterTest.php
+++ b/tests/ReflectionParameterTest.php
@@ -51,14 +51,15 @@ class ReflectionParameterTest extends AbstractTestCase
         ReflectionParameter $parsedParameter,
         \ReflectionParameter        $originalRefParameter
     ): void {
-        $originalParamClass = $originalRefParameter->getClass();
-        $parsedParamClass   = $parsedParameter->getClass();
+        $originalParamType = $originalRefParameter->getType();
+        $parsedParamType   = $parsedParameter->getType();
 
-        if (isset($originalParamClass)) {
-            $this->assertNotNull($parsedParamClass, "Original param class is: {$originalParamClass->name}");
-            $this->assertSame($originalParamClass->getName(), $parsedParamClass->getName());
+        if (isset($originalParamType)) {
+            $this->assertNotNull($parsedParamType, "Original param type is: {$originalParamType}");
+            $this->assertInstanceOf($originalParamType::class, $parsedParamType, "Parsed param type is: {$parsedParamType}");
+            $this->assertSame((string)$originalParamType, (string)$parsedParamType);
         } else {
-            $this->assertNull($parsedParamClass);
+            $this->assertNull($parsedParamType);
         }
     }
 

--- a/tests/ReflectionPropertyTest.php
+++ b/tests/ReflectionPropertyTest.php
@@ -35,6 +35,15 @@ class ReflectionPropertyTest extends AbstractTestCase
         $propertyName   = $refProperty->getName();
         $className      = $parsedClass->getName();
         $parsedProperty = $parsedClass->getProperty($propertyName);
+        // Covers: ReflectionProperty::getDefaultValue() for a property without a default value is deprecated
+        if ($getterName === 'getDefaultValue' && !$refProperty->hasDefaultValue()) {
+            $this->markTestSkipped("Skipping getDefaultValue() for a property without a default value, it is deprecated");
+        }
+
+        // Covers: misc accessors for a trait property without an object
+        if (in_array($getterName, ['getValue', 'getDefaultValue', 'isInitialized', '__toString'], true) && $parsedClass->isTrait()) {
+            $this->markTestSkipped("Skipping accessing trait property without a class, it is deprecated");
+        }
         $expectedValue  = $refProperty->$getterName();
         $actualValue    = $parsedProperty->$getterName();
         // I would like to completely stop maintaining the __toString method
@@ -80,7 +89,7 @@ class ReflectionPropertyTest extends AbstractTestCase
             $parsedProperty->hasDefaultValue(),
             "Presence of default value for property {$className}:{$propertyName} should be equal"
         );
-        if ($originalRefProperty->isStatic()) {
+        if ($originalRefProperty->isStatic() && !$parsedRefClass->isTrait()) {
             $actualValue = $parsedProperty->getValue();
             $this->assertSame($originalRefProperty->getValue(), $actualValue);
         } elseif ($originalRefProperty->hasDefaultValue() && $parsedRefClass->isInstantiable()) {

--- a/tests/ReflectionTypeTest.php
+++ b/tests/ReflectionTypeTest.php
@@ -62,28 +62,6 @@ class ReflectionTypeTest extends TestCase
      * We're already testing it with Go\ParserReflection\ReflectionType
      * elsewhere.
      */
-    public function testTypeConvertToDisplayTypeImplicitlyNullable(): void
-    {
-        $nativeClassRef = new \ReflectionClass('Go\\ParserReflection\\Stub\\ClassWithPhp70ScalarTypeHints');
-        $nativeMethodRef = $nativeClassRef->getMethod('acceptsStringDefaultToNull');
-        $this->assertInstanceOf(\ReflectionMethod::class, $nativeMethodRef);
-        $nativeParamRefArr = $nativeMethodRef->getParameters();
-        $this->assertCount(1, $nativeParamRefArr);
-        $this->assertInstanceOf(\ReflectionParameter::class, $nativeParamRefArr[0]);
-        $nativeTypeRef = $nativeParamRefArr[0]->getType();
-        $this->assertTrue($nativeTypeRef->allowsNull());
-        $this->assertSame('string', $nativeTypeRef->getName());
-        $this->assertStringNotContainsString('\\', get_class($nativeTypeRef));
-        $this->assertInstanceOf(\ReflectionType::class, $nativeTypeRef);
-        $this->assertSame('?string', \Go\ParserReflection\ReflectionType::convertToDisplayType($nativeTypeRef));
-    }
-
-    /**
-     * Testing convertToDisplayType() with native \ReflectionType
-     *
-     * We're already testing it with Go\ParserReflection\ReflectionType
-     * elsewhere.
-     */
     public function testTypeConvertToDisplayTypeImplicitlyUnionNullable(): void
     {
         $nativeClassRef = new \ReflectionClass('Go\\ParserReflection\\Stub\\ClassWithPhp80Features');

--- a/tests/Stub/FileWithClasses70.php
+++ b/tests/Stub/FileWithClasses70.php
@@ -22,7 +22,7 @@ class ClassWithPhp70ScalarTypeHints
     public function acceptsBool(bool $value) {}
     public function acceptsVariadicInteger(int ...$values) {}
     public function acceptsDefaultString(string $class = ReflectionMethod::class, string $name = P::class) {}
-    public function acceptsStringDefaultToNull(string $someName = null) {}
+    public function acceptsStringDefaultToNull(string $someName) {}
 }
 
 class ClassWithPhp70ReturnTypeHints

--- a/tests/Stub/FileWithClasses80.php
+++ b/tests/Stub/FileWithClasses80.php
@@ -16,7 +16,7 @@ use Go\ParserReflection\{ReflectionMethod, ReflectionProperty as P};
 
 class ClassWithPhp80Features
 {
-    public function acceptsStringArrayDefaultToNull(array|string $iterable = null) : array {}
+    public function acceptsStringArrayDefaultToNull(array|string|null $iterable = null) : array {}
 }
 
 /**

--- a/tests/Stub/FileWithFunctions70.php
+++ b/tests/Stub/FileWithFunctions70.php
@@ -7,7 +7,7 @@ namespace Go\ParserReflection\Stub {
 
     function simpleIntArg(int $value) {}
     function simpleArrayOut() : array {}
-    function optionalCallableArg(callable $argument = null) : callable {}
+    function optionalCallableArg(callable $argument) : callable {}
     function objectOut() : \Exception
     {
         return new \Exception();

--- a/tests/Stub/FileWithParameters55.php
+++ b/tests/Stub/FileWithParameters55.php
@@ -35,9 +35,6 @@ namespace Go\ParserReflection\Stub {
         &$byReferenceParam,
         \Traversable $traversable,
         array $arrayParamWithDefault = array(1, 2, 3),
-        array $arrayNullable = null,
-        callable $callableNullable = null,
-        \stdClass $objectNullable = null,
         &$byReferenceNullable = __FUNCTION__,
         $constParam = TEST_PARAMETER,
         $constValueParam = __NAMESPACE__, // This line is long and should be truncated


### PR DESCRIPTION
This PR appears to modernize the library for stricter static analysis (PHPStan level 10) and newer PHP versions by tightening types, refining AST handling, and adding CI workflows/config for PHPStan.

Changes:

 - Add PHPStan configuration/workflow and bump dev dependencies (PHPStan, Rector).
 - Refine reflection/AST resolver typing and safety checks (attributes, types, node evaluation, line/file attributes).
 - Update CI PHP matrix and introduce PHP 8.4/8.4-hook-related adjustments (e.g., re-declared hooked readonly properties, more final classes).