### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   phpunit:
     name: "PHPUnit tests"


### PR DESCRIPTION
Potential fix for [https://github.com/goaop/parser-reflection/security/code-scanning/1](https://github.com/goaop/parser-reflection/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/phpunit.yml` at the workflow root so it applies to all jobs (current and future unless overridden).  
Best minimal fix without changing behavior: set:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI tasks. Place it after the `on:` block (or near top-level keys) and before `jobs:`.

No imports, methods, or dependencies are needed—just YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
