### PR TITLE
docs: refresh CLAUDE.md, README and API docs ahead of 4.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Requires PHP >=8.4. Namespace: `Go\ParserReflection\`.
 # Install dependencies (slow locally — see note below)
 composer install --prefer-source --no-interaction
 
-# Run tests (~6 seconds, ~10,500 tests)
+# Run tests (~3-6 seconds, ~13,700 tests)
 vendor/bin/phpunit
 
 # Run a single test file
@@ -28,7 +28,8 @@ vendor/bin/phpunit tests/ReflectionClassTest.php
 # Run a specific test method
 vendor/bin/phpunit --filter testMethodName
 
-# Static analysis (~5 seconds, 18 known existing errors are normal)
+# Static analysis (~5 seconds, level 10, must report zero errors;
+# known false positives are ignored via phpstan.neon)
 vendor/bin/phpstan analyse src --no-progress
 ```
 
@@ -50,7 +51,8 @@ When you call `new ReflectionClass('SomeClass')`:
 
 - **`ReflectionEngine`** (`src/ReflectionEngine.php`) — static class; central hub. Owns the PHP-Parser instance, AST cache, and locator. Entry points: `parseFile()`, `parseClass()`, `parseClassMethod()`, etc.
 - **`LocatorInterface`** / **`ComposerLocator`** — pluggable class file finder. `ComposerLocator` delegates to Composer's classmap/autoloader. `bootstrap.php` auto-registers `ComposerLocator` on load.
-- **Reflection classes** (`src/Reflection*.php`) — each extends its PHP internal counterpart (e.g. `ReflectionClass extends \ReflectionClass`) and holds an AST node. Methods that require a live object (e.g. `invoke()`) trigger actual class loading and fall back to native reflection.
+- **Reflection classes** (`src/Reflection*.php`) — each extends its PHP internal counterpart (e.g. `ReflectionClass extends \ReflectionClass`) and holds an AST node. Methods that require a live object (e.g. `invoke()`) trigger actual class loading and fall back to native reflection. Enums are covered by `ReflectionEnum`, `ReflectionEnumUnitCase` and `ReflectionEnumBackedCase`; `ReflectionConstant` reflects `const`-declared global/namespaced constants (it mirrors the final native `\ReflectionConstant` API instead of extending it).
+- **`NodeAwareInterface`** — implemented by all parsed reflection classes; exposes the underlying AST node via `getNode()`.
 - **Traits** (`src/Traits/`) — shared logic extracted to avoid duplication:
   - `ReflectionClassLikeTrait` — used by `ReflectionClass`; implements most class inspection methods against the AST
   - `ReflectionFunctionLikeTrait` — shared by `ReflectionMethod` and `ReflectionFunction`
@@ -66,4 +68,4 @@ Tests in `tests/` mirror the reflection class names (e.g. `ReflectionClassTest.p
 
 ### CI
 
-GitHub Actions (`.github/workflows/phpunit.yml`) runs PHPUnit on PHP 8.2, 8.3, 8.4 with both lowest and highest dependency versions.
+GitHub Actions (`.github/workflows/phpunit.yml`) runs PHPUnit on PHP 8.4 and 8.5 with both lowest and highest dependency versions, plus PHP 8.6 as an experimental (allowed-to-fail) job. A separate workflow (`.github/workflows/phpstan.yml`) runs PHPStan at level 10 on PHP 8.4.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Parser Reflection API Library
 
 ## 🔍 Static Code Analysis Meets Reflection
 
-**Parser Reflection API** brings the power of PHP's Reflection API to static code analysis. Built on top of [nikic/php-parser](https://github.com/nikic/PHP-Parser), this library lets you introspect classes, methods, and properties **without ever loading them into memory**.
+**Parser Reflection API** brings the power of PHP's Reflection API to static code analysis. Built on top of [nikic/php-parser](https://github.com/nikic/PHP-Parser), this library lets you introspect classes, interfaces, traits, enums, methods, properties, functions and constants **without ever loading them into memory**.
 
 ### ✨ Key Features
 
@@ -15,7 +15,8 @@ Forget autoloading. This library parses your PHP source files directly into an A
 
 - 📊 **Source code analysis** — inspect structure without executing anything
 - 🧪 **Safe introspection** — avoid triggering constructors or static initializers
-- 🔌 **Drop-in compatible** — extends native `\ReflectionClass`, `\ReflectionMethod`, etc.
+- 🔌 **Drop-in compatible** — extends native `\ReflectionClass`, `\ReflectionMethod`, `\ReflectionEnum`, etc.
+- 🆕 **Modern PHP support** — enums, attributes (incl. `IS_INSTANCEOF` filtering), first-class callables, PHP 8.4 property hooks and lazy objects, `const`-declared global constants
 
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/goaop/parser-reflection/phpunit.yml?branch=master)
 ![PHPStan Badge](https://img.shields.io/badge/PHPStan-level%2010-brightgreen.svg?style=flat&link=https%3A%2F%2Fphpstan.org%2Fuser-guide%2Frule-levels)
@@ -127,7 +128,9 @@ To understand how library works let's look at what happens during the call to th
 Compatibility
 ------------
 
-All parser reflection classes extend PHP internal reflection classes, this means that you can use `\Go\ParserReflection\ReflectionClass` instance in any place that asks for `\ReflectionClass` instance. All reflection methods should be compatible with original ones, providing an  except methods that requires object manipulation, such as `invoke()`, `invokeArgs()`, `setAccessible()`, etc. These methods will trigger the process of class loading and switching to the internal reflection.
+All parser reflection classes extend PHP internal reflection classes, this means that you can use `\Go\ParserReflection\ReflectionClass` instance in any place that asks for `\ReflectionClass` instance. All reflection methods should be compatible with original ones, except methods that require object manipulation, such as `invoke()`, `invokeArgs()`, `setAccessible()`, etc. These methods will trigger the process of class loading and switching to the internal reflection.
+
+The only exception is `\Go\ParserReflection\ReflectionConstant`: the native `\ReflectionConstant` class is declared as `final`, so this class mirrors its public API instead of extending it.
 
 [0]: docs/reflection_file.md
 [1]: docs/reflection_file_namespace.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Reference
 ---------
 
 - [`ReflectionClass`](reflection_class.md)
+- [`ReflectionConstant`](reflection_constant.md)
+- [`ReflectionEnum`](reflection_enum.md)
 - [`ReflectionFile`](reflection_file.md)
 - [`ReflectionFileNamespace`](reflection_file_namespace.md)
 - [`ReflectionFunction`](reflection_function.md)

--- a/docs/reflection_constant.md
+++ b/docs/reflection_constant.md
@@ -1,0 +1,60 @@
+ReflectionConstant
+==============
+
+The `ReflectionConstant` class reports an information about a global or namespaced constant declared with the `const` keyword. The native [`ReflectionConstant`][0] class is declared as `final`, therefore this class can not extend it and mirrors its public API instead.
+
+Constants defined via `define(...)` are not supported, because they are created at runtime and can not be resolved statically.
+
+API
+---
+
+```php
+final class ReflectionConstant implements NodeAwareInterface, Reflector, Stringable
+{
+    public function __construct(string $constantName) {}
+    public function getName(): string {}
+    public function getShortName(): string {}
+    public function getNamespaceName(): string {}
+    public function getValue(): mixed {}
+    public function isDeprecated(): bool {}
+    public function getAttributes(?string $name = null, int $flags = 0): array {}
+    public function getNode(): PhpParser\Node\Const_ {}
+}
+```
+
+Methods
+-------
+
+- `ReflectionConstant::__construct(string $constantName)`
+
+  Constructs an instance of `ReflectionConstant` for the given fully-qualified constant name.
+
+- `ReflectionConstant::getName()`
+
+  Returns the fully-qualified name of the constant.
+
+- `ReflectionConstant::getShortName()`
+
+  Returns the short name of the constant, without its namespace.
+
+- `ReflectionConstant::getNamespaceName()`
+
+  Returns the namespace the constant is declared in, or an empty string for the global namespace.
+
+- `ReflectionConstant::getValue()`
+
+  Returns the statically-resolved value of the constant.
+
+- `ReflectionConstant::isDeprecated()`
+
+  Checks if the constant is marked with the `#[\Deprecated]` attribute.
+
+- `ReflectionConstant::getAttributes(?string $name = null, int $flags = 0)`
+
+  Returns the list of attributes declared on the constant, with optional filtering by name (including `ReflectionAttribute::IS_INSTANCEOF` flag support).
+
+- `ReflectionConstant::getNode()`
+
+  Returns the underlying AST node with the `NAME = value` declaration.
+
+[0]: https://php.net/manual/en/class.reflectionconstant.php

--- a/docs/reflection_enum.md
+++ b/docs/reflection_enum.md
@@ -1,0 +1,31 @@
+ReflectionEnum
+==============
+
+The `ReflectionEnum` class reports an information about an enum. This class is available in the standard PHP, so for any questions, please look at documentation for [`ReflectionEnum`][0]
+
+Enum cases are represented by the `ReflectionEnumUnitCase` and `ReflectionEnumBackedCase` classes, which extend their native counterparts [`ReflectionEnumUnitCase`][1] and [`ReflectionEnumBackedCase`][2].
+
+Enum-specific API
+---------
+
+```php
+final class ReflectionEnum extends \ReflectionEnum
+{
+    public function getBackingType(): ?ReflectionNamedType {}
+    public function getCase(string $name): ReflectionEnumUnitCase|ReflectionEnumBackedCase {}
+    public function getCases(): array {}
+    public function hasCase(string $name): bool {}
+    public function isBacked(): bool {}
+}
+```
+
+But be careful, that several methods require the enum to be loaded into the memory, otherwise an exception will be thrown.
+
+List of methods, that require enum to be loaded
+---------
+
+- ReflectionEnumUnitCase::getValue / ReflectionEnumBackedCase::getValue — Returns the concrete enum case object
+
+[0]: https://php.net/manual/en/class.reflectionenum.php
+[1]: https://php.net/manual/en/class.reflectionenumunitcase.php
+[2]: https://php.net/manual/en/class.reflectionenumbackedcase.php

--- a/docs/reflection_file_namespace.md
+++ b/docs/reflection_file_namespace.md
@@ -13,8 +13,11 @@ class ReflectionFileNamespace
     public function getClass($className) {}
     public function getClasses() {}
     public function getConstant($constantName) {}
-    public function getConstants() {}
+    public function getConstants($withDefined = false) {}
+    public function getReflectionConstant($constantName) {}
+    public function getReflectionConstants() {}
     public function getDocComment() {}
+    public function getEnums() {}
     public function getEndLine() {}
     public function getFileName() {}
     public function getFunction($functionName) {}
@@ -47,9 +50,21 @@ Methods
   
   Returns a value for the constant with name `$constantName` in the file namespace or `false` if there is no such a constant in the current namespace.
   
-- `ReflectionFileNamespace::getConstants()`
+- `ReflectionFileNamespace::getConstants($withDefined = false)`
 
-  Returns an array with all available constants in the namespace.
+  Returns an array with all available constants in the namespace. If `$withDefined` is `true`, top-level `define(...)` statements will be included as well.
+
+- `ReflectionFileNamespace::getReflectionConstant($constantName)`
+
+  Returns the concrete [`ReflectionConstant`][2] from the file namespace or `false` if there is no such a constant in the current namespace.
+
+- `ReflectionFileNamespace::getReflectionConstants()`
+
+  Returns an array with available constants in the namespace. Each `const` definition will be represented as a single instance of [`ReflectionConstant`][2] in this list.
+
+- `ReflectionFileNamespace::getEnums()`
+
+  Returns an array with available enums in the namespace. Each enum definition will be represented as a single instance of [`ReflectionEnum`][3] in this list.
 
 - `ReflectionFileNamespace::getDocComment()`
 
@@ -97,3 +112,5 @@ Methods
 
 [0]: reflection_class.md
 [1]: reflection_function.md
+[2]: reflection_constant.md
+[3]: reflection_enum.md


### PR DESCRIPTION
Pre-release documentation refresh so the repo is accurate before tagging `4.0.0` on `master`.

## CLAUDE.md

- Corrected the CI section: PHPUnit now runs on **PHP 8.4 and 8.5** (lowest/highest deps) plus **8.6 experimental**, and a separate `phpstan.yml` workflow runs **PHPStan level 10** on PHP 8.4 (the file previously claimed PHP 8.2/8.3/8.4).
- Updated the test-suite figure to **~13,700 tests** (verified locally on PHP 8.5: 13,743 tests, 15,392 assertions, ~3 s).
- Replaced the stale "18 known existing errors are normal" PHPStan note — analysis at level 10 must now report **zero errors** (known false positives are ignored in `phpstan.neon`; latest master run is green).
- Documented the new classes added since 3.1.0: `ReflectionEnum`, `ReflectionEnumUnitCase`, `ReflectionEnumBackedCase`, `ReflectionConstant`, and `NodeAwareInterface`.

## README.md

- Feature list now mentions enums, attributes (incl. `IS_INSTANCEOF` filtering), first-class callables, PHP 8.4 property hooks / lazy objects, and `const`-declared global constants.
- Fixed a long-standing typo in the *Compatibility* section ("providing an  except methods…").
- Noted that `ReflectionConstant` mirrors the `final` native `\ReflectionConstant` API instead of extending it.
- Badges checked: workflow, PHPStan level 10, PHP >= 8.4, release/downloads/license badges are all already correct — no changes needed.

## docs/

- New reference pages: `docs/reflection_enum.md` and `docs/reflection_constant.md`, linked from `docs/README.md`.
- `docs/reflection_file_namespace.md`: documented `getEnums()`, `getReflectionConstant()` / `getReflectionConstants()` and the `$withDefined` flag on `getConstants()`.

No source-code changes; markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK

---
_Generated by [Claude Code](https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK)_