### PR TITLE
ci: allow a PAT to drive the cascade PR

### DIFF
--- a/.github/workflows/cascade-merge.yml
+++ b/.github/workflows/cascade-merge.yml
@@ -21,7 +21,13 @@ jobs:
     steps:
       - name: "Open or refresh the 4.x -> master pull request"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The default GITHUB_TOKEN can open/merge PRs, but pull_request-triggered
+          # workflows (required status checks) on a PR it opens are held for manual
+          # approval by GitHub's anti-recursion safeguard. Set the CASCADE_TOKEN repo
+          # secret to a PAT (Contents: write, Pull requests: write) so required checks
+          # on the cascade PR run without manual approval; falls back to GITHUB_TOKEN
+          # if unset (checks will need one-time manual approval in that case).
+          GH_TOKEN: ${{ secrets.CASCADE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -e


### PR DESCRIPTION
## Summary
- The `Cascade 4.x into master` workflow (added in the previous push to `4.x`) uses the default `GITHUB_TOKEN` to open/auto-merge a `4.x` → `master` PR.
- That PR's own required checks (PHPUnit, PHPStan) never ran: they're stuck as `action_required` because GitHub's anti-recursion safeguard holds `pull_request`-triggered workflow runs for manual approval when the PR was opened via `GITHUB_TOKEN` — see [PR #216](https://github.com/goaop/parser-reflection/pull/216).
- This adds an optional `CASCADE_TOKEN` repo secret (a PAT with `Contents: write` + `Pull requests: write`) that the workflow prefers over `GITHUB_TOKEN` when set, so a real actor opens the PR and downstream checks run without manual approval. Falls back to `GITHUB_TOKEN` if the secret isn't configured (current behavior).

## Test plan
- [ ] Add a `CASCADE_TOKEN` repo secret, then push a change to `4.x` and confirm the resulting cascade PR's checks run automatically (no `action_required` state).
- [ ] Also enable **Settings → General → Pull Requests → Allow auto-merge** (currently off — confirmed via API), otherwise `gh pr merge --auto` keeps failing even once checks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK

---
_Generated by [Claude Code](https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK)_