### PR TITLE
chore!: master now targets PHP 8.5+ only

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,9 +10,9 @@ Parser Reflection is a **deprecated** PHP library that provides reflection capab
 
 **CRITICAL: Set timeouts of 30+ minutes for all composer commands. NEVER CANCEL composer operations.**
 
-1. **Verify PHP version**: Requires PHP >=8.2
+1. **Verify PHP version**: Requires PHP >=8.5
    ```bash
-   php --version  # Should show PHP 8.2+
+   php --version  # Should show PHP 8.5+
    ```
 
 2. **Install dependencies** (takes 15-25 minutes due to GitHub API rate limits):
@@ -85,10 +85,10 @@ php /tmp/test_reflection.php
 - `vendor/` - Dependencies (created during build)
 
 ### Important Files
-- `composer.json` - Dependencies: php >=8.2, nikic/php-parser ^5.0
+- `composer.json` - Dependencies: php >=8.5, nikic/php-parser ^5.0
 - `phpunit.xml.dist` - Test configuration (1536M memory limit)
 - `rector.php` - Code quality rules
-- `.github/workflows/phpunit.yml` - CI pipeline (PHP 8.2, 8.3, 8.4)
+- `.github/workflows/phpunit.yml` - CI pipeline (PHP 8.5, with 8.6 as experimental)
 
 ## Common Issues and Troubleshooting
 
@@ -143,12 +143,12 @@ php /tmp/test_reflection.php
 - Core functionality requires nikic/php-parser for AST generation
 - Tests use Composer's autoloader for class location
 - Memory usage can be high for large codebases (configure php.ini accordingly)
-- Compatible with PHP 8.2+ (tested on 8.2, 8.3, 8.4)
+- Compatible with PHP 8.5+ (tested on 8.5, with 8.6 as experimental)
 
 ## CI/Build Pipeline Reference
 
 The GitHub Actions pipeline (`.github/workflows/phpunit.yml`) runs:
-- Matrix testing: PHP 8.2, 8.3, 8.4 on Ubuntu
+- Matrix testing: PHP 8.5 on Ubuntu, plus PHP 8.6 as an experimental (allowed-to-fail) job
 - Dependency variations: lowest, highest
 - Standard `composer install` (works in CI with GitHub tokens)
 - PHPUnit test suite execution

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Setup PHP 8.4
+      - name: Setup PHP 8.5
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           github-token: ${{ secrets.GH_PAT_TOKEN || github.token }}
           tools: composer:v2
           coverage: none

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: "PHPStan analysis - PHP8.4"
+    name: "PHPStan analysis - PHP8.5"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
@@ -19,7 +19,7 @@ jobs:
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: "8.5"
           ini-values: memory_limit=-1
           tools: composer:v2
       - name: "Cache dependencies"
@@ -28,8 +28,8 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: "php-8.4"
-          restore-keys: "php-8.4"
+          key: "php-8.5"
+          restore-keys: "php-8.5"
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"
       - name: "Static analysis"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,7 +25,6 @@ jobs:
           - "highest"
         php-version:
           - "8.5"
-          - "8.4"
         operating-system:
           - "ubuntu-latest"
         experimental:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Parser Reflection is a PHP library that extends PHP's internal reflection classes using nikic/PHP-Parser for static analysis. It reflects PHP code without loading classes into memory by parsing source files into an AST.
 
-Requires PHP >=8.4. Namespace: `Go\ParserReflection\`.
+Requires PHP >=8.5. Namespace: `Go\ParserReflection\`.
 
 ## Agent runtime requirement
 
-- Agents must run on PHP **8.4 or higher**.
-- If the runtime is PHP **8.3.x**, agents should not attempt dependency installation or test validation and should report that PHP **8.4+** is required.
+- Agents must run on PHP **8.5 or higher**.
+- If the runtime is PHP **8.4.x or lower**, agents should not attempt dependency installation or test validation and should report that PHP **8.5+** is required.
 
 ## Commands
 
@@ -68,4 +68,4 @@ Tests in `tests/` mirror the reflection class names (e.g. `ReflectionClassTest.p
 
 ### CI
 
-GitHub Actions (`.github/workflows/phpunit.yml`) runs PHPUnit on PHP 8.4 and 8.5 with both lowest and highest dependency versions, plus PHP 8.6 as an experimental (allowed-to-fail) job. A separate workflow (`.github/workflows/phpstan.yml`) runs PHPStan at level 10 on PHP 8.4.
+GitHub Actions (`.github/workflows/phpunit.yml`) runs PHPUnit on PHP 8.5 with both lowest and highest dependency versions, plus PHP 8.6 as an experimental (allowed-to-fail) job. A separate workflow (`.github/workflows/phpstan.yml`) runs PHPStan at level 10 on PHP 8.5.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Forget autoloading. This library parses your PHP source files directly into an A
 [![GitHub release](https://img.shields.io/github/release/goaop/parser-reflection.svg)](https://github.com/goaop/parser-reflection/releases/latest)
 [![Total Downloads](https://img.shields.io/packagist/dt/goaop/parser-reflection.svg)](https://packagist.org/packages/goaop/parser-reflection)
 [![Daily Downloads](https://img.shields.io/packagist/dd/goaop/parser-reflection.svg)](https://packagist.org/packages/goaop/parser-reflection)
-[![PHP Version](https://img.shields.io/badge/php-%3E%3D%208.4-8892BF.svg)](https://php.net/)
+[![PHP Version](https://img.shields.io/badge/php-%3E%3D%208.5-8892BF.svg)](https://php.net/)
 [![License](https://img.shields.io/packagist/l/goaop/parser-reflection.svg)](https://packagist.org/packages/goaop/parser-reflection)
 [![Sponsor](https://img.shields.io/badge/Sponsor-❤️-lightgray?style=flat&logo=github)](https://github.com/sponsors/lisachenko)
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": ">=8.4",
+    "php": ">=8.5",
     "nikic/php-parser": "^5.4"
   },
   "require-dev": {
@@ -33,7 +33,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "4.x-dev"
+      "dev-master": "8.5-dev"
     }
   }
 }

--- a/src/Resolver/TypeExpressionResolver.php
+++ b/src/Resolver/TypeExpressionResolver.php
@@ -157,14 +157,12 @@ class TypeExpressionResolver
         $typeName = $node->toString();
 
         // PHP 8.5+ changed ReflectionNamedType::getName() to return the actual FQCN for 'self'
-        // and 'parent', whereas PHP 8.4 and earlier preserve the keywords as-is.
+        // and 'parent' instead of preserving the keywords as-is.
         // 'static' is always kept as-is (late static binding, preserved by native reflection).
-        if (PHP_VERSION_ID >= 80500) {
-            if ($typeName === 'self') {
-                $typeName = $this->selfClassName ?? $typeName;
-            } elseif ($typeName === 'parent') {
-                $typeName = $this->parentClassName ?? $typeName;
-            }
+        if ($typeName === 'self') {
+            $typeName = $this->selfClassName ?? $typeName;
+        } elseif ($typeName === 'parent') {
+            $typeName = $this->parentClassName ?? $typeName;
         }
 
         return new ReflectionNamedType($typeName, $this->hasDefaultNull, false);


### PR DESCRIPTION
## Summary

`master` becomes the line for PHP 8.5 development going forward. The 8.4-compatible `4.x` branch (released as 4.0.0) continues to receive fixes and cascades them forward into `master` via the [cascade-merge workflow](.github/workflows/cascade-merge.yml) added in #216.

- **composer.json**: `require.php` bumped from `>=8.4` to `>=8.5`; `extra.branch-alias.dev-master` changed from `4.x-dev` to `8.5-dev`, as requested.
- **README.md**: PHP version badge updated to `>=8.5`.
- **CLAUDE.md**: "Requires PHP" line, the Agent runtime requirement section (now rejects 8.4.x and below), and the CI description updated to 8.5.
- **CI**: dropped the `8.4` leg from the `phpunit.yml` matrix (`8.5` lowest/highest + `8.6` experimental remain), moved the `phpstan.yml` job and the Copilot `copilot-setup-steps.yml` PHP setup step from 8.4 to 8.5.
- **`.github/copilot-instructions.md`**: this file was already out of sync with the repo (still said `>=8.2` and an `8.2/8.3/8.4` CI matrix even before this change) — updated its PHP-version facts to match the new 8.5 baseline while it was being touched.

Left untouched: mentions of specific PHP versions that describe *when a language feature was introduced* rather than the library's minimum requirement — e.g. README's "PHP 8.4 property hooks" feature callout, `PHP_VERSION_ID`-gated test logic, and the versioned test stub filenames (`FileWithClasses82.php` etc.), since the AST parser continues to support reflecting code written for older PHP versions regardless of the host's minimum requirement.

## Test plan
- [x] `vendor/bin/phpunit` — 13,743 tests pass locally on PHP 8.5.9
- [x] `composer.json` validated as well-formed JSON
- [x] CI (PHPUnit 8.5 lowest/highest, PHPUnit 8.6 experimental, PHPStan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK

---
_Generated by [Claude Code](https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK)_