### PR TITLE
[PHP 8.6] Test scaffolding and deprecation-clean audit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,10 +11,11 @@ permissions:
 
 jobs:
   phpunit:
-    name: "PHPUnit tests"
+    name: "PHPUnit tests (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps)${{ matrix.experimental && ' [experimental]' || '' }}"
 
     runs-on: ${{ matrix.operating-system }}
 
+    # Experimental rows (PHP 8.6 beta) are allowed to fail until PHP 8.6 reaches GA
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
@@ -73,4 +74,12 @@ jobs:
         run: "composer install --no-interaction --no-progress --no-suggest${{ matrix.experimental && ' --ignore-platform-req=php+' || '' }}"
 
       - name: "Tests"
+        id: "tests"
         run: "vendor/bin/phpunit"
+
+      # "continue-on-error" hides a failing experimental row from the checks list,
+      # therefore its real outcome is written to the run summary explicitly
+      - name: "Report experimental outcome"
+        if: ${{ always() && matrix.experimental }}
+        run: |
+          echo "PHP $(php -r 'echo PHP_VERSION;') / ${{ matrix.dependencies }} dependencies: **${{ steps.tests.outcome }}** (experimental, allowed to fail until GA)" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ When you call `new ReflectionClass('SomeClass')`:
 
 Tests in `tests/` mirror the reflection class names (e.g. `ReflectionClassTest.php`). PHP version-specific stub files in `tests/Stub/` (e.g. `FileWithClasses84.php`) contain the PHP code being reflected. Tests extend `AbstractTestCase` which sets up the `ReflectionEngine` with a `ComposerLocator`.
 
+Stubs for a PHP version newer than the supported baseline follow the `FileWith*86.php` naming convention (`FileWithClasses86.php` is the baseline one, per-feature stubs get their own file). They are only yielded by `AbstractTestCase::getFilesToAnalyze()` behind a `PHP_VERSION_ID >= 80600` check, because the data providers `include_once` every stub they yield. Since the reflection engine analyzes sources without loading them, static assertions on such stubs may run on any runtime; every assertion that needs the newer runtime (native reflection parity, for instance) must be guarded with the same `PHP_VERSION_ID >= 80600` check so the suite stays green on PHP 8.5. See `tests/Php86ParsingTest.php` for the reference wiring.
+
 ### CI
 
 GitHub Actions (`.github/workflows/phpunit.yml`) runs PHPUnit on PHP 8.5 with both lowest and highest dependency versions, plus PHP 8.6 as an experimental (allowed-to-fail) job. A separate workflow (`.github/workflows/phpstan.yml`) runs PHPStan at level 10 on PHP 8.5.

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -88,6 +88,11 @@ abstract class AbstractTestCase extends TestCase
         if (PHP_VERSION_ID >= 80400) {
             yield 'PHP8.4' => [__DIR__ . '/Stub/FileWithClasses84.php'];
         }
+        // Stubs named "FileWith*86.php" may only be loaded by a PHP 8.6+ runtime, therefore every
+        // assertion that depends on them has to be guarded with the same PHP_VERSION_ID check
+        if (PHP_VERSION_ID >= 80600) {
+            yield 'PHP8.6' => [__DIR__ . '/Stub/FileWithClasses86.php'];
+        }
     }
 
     /**

--- a/tests/Php86ParsingTest.php
+++ b/tests/Php86ParsingTest.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+/**
+ * Parser Reflection API
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\ParserReflection;
+
+use Go\ParserReflection\Locator\CallableLocator;
+use Go\ParserReflection\Locator\ComposerLocator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves the PHP 8.6 test scaffolding: the "FileWith*86.php" stub naming convention and the
+ * "PHP_VERSION_ID >= 80600" guard convention used for runtime-only assertions.
+ *
+ * The static part of this test runs on every supported runtime, because the reflection engine
+ * analyzes sources without loading them. Only the parity assertions against native reflection
+ * require the stub to be loaded, and those are guarded by the PHP version check.
+ */
+class Php86ParsingTest extends TestCase
+{
+    public const STUB_FILE = '/Stub/FileWithClasses86.php';
+
+    public const STUB_NAMESPACE = 'Go\ParserReflection\Stub';
+
+    public const STUB_CLASS = 'Go\ParserReflection\Stub\ClassWithPhp86Members';
+
+    public const STUB_ENUM = 'Go\ParserReflection\Stub\EnumWithPhp86Cases';
+
+    private string $stubFileName;
+
+    protected function setUp(): void
+    {
+        $resolvedFileName = stream_resolve_include_path(__DIR__ . self::STUB_FILE);
+        $this->assertIsString($resolvedFileName, 'PHP 8.6 stub file should be available');
+
+        $this->stubFileName = $resolvedFileName;
+
+        // The stub file is not autoloadable by its class names, so the engine gets an explicit locator
+        $stubFileName = $resolvedFileName;
+        ReflectionEngine::init(new CallableLocator(
+            static fn(string $className): false|string
+                => str_starts_with($className, self::STUB_NAMESPACE . '\\') ? $stubFileName : false
+        ));
+    }
+
+    protected function tearDown(): void
+    {
+        // Restores the default locator for the following tests, because some of them replace it
+        ReflectionEngine::init(new ComposerLocator());
+    }
+
+    public function testStubFileIsParsed(): void
+    {
+        $reflectionFile = new ReflectionFile($this->stubFileName);
+
+        $this->assertTrue($reflectionFile->isStrictMode());
+        $this->assertTrue($reflectionFile->hasFileNamespace(self::STUB_NAMESPACE));
+    }
+
+    public function testStubClassesAreFound(): void
+    {
+        $reflectionNamespace = $this->getStubNamespace();
+        $parsedClassNames    = array_keys($reflectionNamespace->getClasses());
+
+        $this->assertContains(self::STUB_NAMESPACE . '\InterfaceWithPhp86Contract', $parsedClassNames);
+        $this->assertContains(self::STUB_NAMESPACE . '\TraitWithPhp86Helpers', $parsedClassNames);
+        $this->assertContains(self::STUB_NAMESPACE . '\AbstractClassWithPhp86Members', $parsedClassNames);
+        $this->assertContains(self::STUB_CLASS, $parsedClassNames);
+        $this->assertContains(self::STUB_ENUM, $parsedClassNames);
+    }
+
+    public function testStubClassIsReflectedStatically(): void
+    {
+        $parsedClass = $this->getStubNamespace()->getClass(self::STUB_CLASS);
+
+        $this->assertSame(self::STUB_CLASS, $parsedClass->getName());
+        $this->assertSame($this->stubFileName, $parsedClass->getFileName());
+        $this->assertTrue($parsedClass->isFinal());
+        $this->assertSame(self::STUB_NAMESPACE . '\AbstractClassWithPhp86Members', $parsedClass->getParentClass()->getName());
+        $this->assertContains(self::STUB_NAMESPACE . '\InterfaceWithPhp86Contract', $parsedClass->getInterfaceNames());
+        $this->assertSame('php86-class', $parsedClass->getConstant('LABEL'));
+        $this->assertTrue($parsedClass->hasMethod('helperName'), 'Trait method should be inherited from the parent');
+
+        $parsedParent = $this->getStubNamespace()->getClass(self::STUB_NAMESPACE . '\AbstractClassWithPhp86Members');
+        $this->assertTrue($parsedParent->isAbstract());
+        $this->assertSame([self::STUB_NAMESPACE . '\TraitWithPhp86Helpers'], $parsedParent->getTraitNames());
+
+        $parsedMethod = $parsedClass->getMethod('combine');
+        $this->assertSame('string', (string) $parsedMethod->getReturnType());
+        $this->assertTrue($parsedMethod->isVariadic());
+        $this->assertSame(
+            ['first', 'second', 'rest'],
+            array_map(
+                static fn(\ReflectionParameter $parameter): string => $parameter->getName(),
+                $parsedMethod->getParameters()
+            )
+        );
+        $this->assertSame('int|float', (string) $parsedMethod->getParameters()[0]->getType());
+    }
+
+    public function testStubEnumIsReflectedStatically(): void
+    {
+        $parsedEnum = new ReflectionEnum(self::STUB_ENUM, $this->getStubNamespace()->getClass(self::STUB_ENUM)->getNode());
+
+        $this->assertTrue($parsedEnum->isBacked());
+        $this->assertSame('string', (string) $parsedEnum->getBackingType());
+        $this->assertSame(
+            ['First', 'Second'],
+            array_map(
+                static fn(\ReflectionEnumUnitCase $case): string => $case->getName(),
+                $parsedEnum->getCases()
+            )
+        );
+    }
+
+    public function testStubIsAnalyzableWithoutLoadingOnOlderRuntimes(): void
+    {
+        if (PHP_VERSION_ID >= 80600) {
+            $this->markTestSkipped('The PHP 8.6 stub is loaded by the parity data providers on this runtime');
+        }
+
+        $parsedClass = new ReflectionClass(self::STUB_CLASS);
+
+        $this->assertSame(self::STUB_CLASS, $parsedClass->getName());
+        $this->assertFalse(class_exists(self::STUB_CLASS, false), 'Stub class should not be loaded');
+        $this->assertTrue($parsedClass->hasMethod('describe'));
+    }
+
+    /**
+     * Demonstrates the "PHP_VERSION_ID >= 80600" guard convention for runtime-only assertions
+     */
+    public function testStubMatchesNativeReflectionOnPhp86(): void
+    {
+        if (PHP_VERSION_ID < 80600) {
+            $this->markTestSkipped('Native reflection parity for the 8.6 stub requires PHP 8.6 runtime');
+        }
+
+        include_once $this->stubFileName;
+
+        $parsedClass = $this->getStubNamespace()->getClass(self::STUB_CLASS);
+        $nativeClass = new \ReflectionClass(self::STUB_CLASS);
+
+        $this->assertSame($nativeClass->isFinal(), $parsedClass->isFinal());
+        $this->assertSame($nativeClass->getParentClass()->getName(), $parsedClass->getParentClass()->getName());
+        $this->assertSame($nativeClass->getInterfaceNames(), $parsedClass->getInterfaceNames());
+        $this->assertSame($nativeClass->getTraitNames(), $parsedClass->getTraitNames());
+        $this->assertSame($nativeClass->getConstants(), $parsedClass->getConstants());
+        $this->assertSame(
+            array_map(static fn(\ReflectionMethod $method): string => $method->getName(), $nativeClass->getMethods()),
+            array_map(static fn(\ReflectionMethod $method): string => $method->getName(), $parsedClass->getMethods())
+        );
+        $this->assertSame(
+            array_map(static fn(\ReflectionProperty $property): string => $property->getName(), $nativeClass->getProperties()),
+            array_map(static fn(\ReflectionProperty $property): string => $property->getName(), $parsedClass->getProperties())
+        );
+    }
+
+    private function getStubNamespace(): ReflectionFileNamespace
+    {
+        return (new ReflectionFile($this->stubFileName))->getFileNamespace(self::STUB_NAMESPACE);
+    }
+}

--- a/tests/Stub/FileWithClasses86.php
+++ b/tests/Stub/FileWithClasses86.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Parser Reflection API
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+declare(strict_types=1);
+
+namespace Go\ParserReflection\Stub;
+
+/**
+ * Baseline stub for the PHP 8.6 test scaffolding.
+ *
+ * It intentionally contains only syntax that is already valid and parseable, so that the
+ * "FileWith*86.php" naming convention and the "PHP_VERSION_ID >= 80600" guard used by
+ * {@see \Go\ParserReflection\AbstractTestCase::getFilesToAnalyze()} are proven by real tests
+ * before the actual PHP 8.6 features land in their own per-feature stubs.
+ *
+ * Per-feature stubs that require the 8.6 runtime (partial function application, readonly
+ * property defaults, "#[\Override]" on class constants, ...) must be added as separate
+ * "FileWith<Feature>86.php" files, and every assertion that needs the 8.6 runtime has to be
+ * guarded with "PHP_VERSION_ID >= 80600" so that the suite stays green on PHP 8.5.
+ *
+ * @see https://www.php.net/manual/en/migration86.php
+ */
+
+const PHP86_STUB_VERSION = '8.6';
+
+interface InterfaceWithPhp86Contract
+{
+    public const string CONTRACT_NAME = 'php86';
+
+    public function describe(): string;
+}
+
+trait TraitWithPhp86Helpers
+{
+    public function helperName(): string
+    {
+        return static::class;
+    }
+}
+
+abstract class AbstractClassWithPhp86Members implements InterfaceWithPhp86Contract
+{
+    use TraitWithPhp86Helpers;
+
+    public const int DEFAULT_PRIORITY = 10;
+
+    protected function priority(): int
+    {
+        return self::DEFAULT_PRIORITY;
+    }
+}
+
+final class ClassWithPhp86Members extends AbstractClassWithPhp86Members
+{
+    public const string LABEL = 'php86-class';
+
+    public static int $counter = 0;
+
+    private readonly string $identifier;
+
+    public function __construct(
+        string $identifier = 'default',
+        public array $options = ['enabled' => true],
+    ) {
+        $this->identifier = $identifier;
+    }
+
+    public function describe(): string
+    {
+        return self::LABEL . ':' . $this->identifier;
+    }
+
+    public function combine(int|float $first, ?string $second = null, int ...$rest): string
+    {
+        return $first . ($second ?? '') . array_sum($rest);
+    }
+
+    public static function create(string $identifier = 'created'): static
+    {
+        return new static($identifier);
+    }
+}
+
+enum EnumWithPhp86Cases: string implements InterfaceWithPhp86Contract
+{
+    case First  = 'first';
+    case Second = 'second';
+
+    public const string CONTRACT_NAME = 'php86-enum';
+
+    public function describe(): string
+    {
+        return self::CONTRACT_NAME . ':' . $this->value;
+    }
+}
+
+function functionWithPhp86Signature(
+    InterfaceWithPhp86Contract $contract,
+    string $prefix = PHP86_STUB_VERSION,
+): string {
+    return $prefix . '/' . $contract->describe();
+}


### PR DESCRIPTION
Refs #220 (part of epic #219).

Establishes the PHP 8.6 test scaffolding, audits the code base against the "Deprecations for PHP 8.6" RFC batch, and makes the experimental 8.6 CI row readable. No library behaviour changes — `src/` is untouched.

## 1. Stub / guard scaffolding

- **`tests/Stub/FileWithClasses86.php`** — baseline 8.6 stub (interface, trait, abstract class, final class with a promoted property and a variadic union-typed method, backed enum, namespaced function and constant). It deliberately uses only syntax that is already valid and parseable, so per-feature 8.6 stubs (PFA, readonly defaults, `#[\Override]` on constants, …) can be added later as separate `FileWith<Feature>86.php` files by their own tickets.
- **`AbstractTestCase::getFilesToAnalyze()`** — yields the stub behind `PHP_VERSION_ID >= 80600`. The guard is load-bearing: the parity data providers `include_once` every stub they yield, so a `*86.php` stub must never reach an older runtime.
- **`tests/Php86ParsingTest.php`** — proves the wiring in both directions. The static assertions (file parsing, class/enum discovery, methods, parameters, types, constants, traits) run on every runtime, because the engine analyzes sources without loading them; the native-reflection parity test is guarded with `PHP_VERSION_ID >= 80600`, and the "reflect by name without loading" test is guarded the other way, since the stub is loaded by the parity providers on 8.6.
- **`CLAUDE.md`** — documents both conventions for future contributors.

On 8.6 the stub also flows through the whole existing parity matrix, which is where the extra ~1090 tests come from.

## 2. Deprecation audit

Checked `src/` and `tests/` against the accepted items of the [Deprecations for PHP 8.6 RFC](https://wiki.php.net/rfc/deprecations_php_8_6): `is_double()`/`is_integer()`/`is_long()`/`doubleval()`, `return` from `finally`, `list()`, `let`/`is`/`readonly`/`_` as identifiers, `namespace` as a class constant, `strcoll()`, `SORT_LOCALE_STRING`, `metaphone()`, `spl_classes()`, `spl_object_hash()`, `SplFileObject` CSV methods, `mysqli_stmt_init()`/`mysqli_get_charset()`, case-insensitive `define()`, `is_a()`/`is_subclass_of()` with a string subject and `allow_string = false`, objects passed to `array_walk()`/`array_walk_recursive()`/`mb_convert_variables()`/`http_build_query()`/`deflate_init()`/`inflate_init()`, `session_set_save_handler()` without `create_sid()`/`validateId()`, `ArrayIterator` inheriting `ArrayObject` implementations, and the Reflection items (`ReflectionProperty::setValue()`/`setRawValue()` with wrong types, `ReflectionMethod::invoke()`/`invokeArgs()` with an object for a static method).

**Result: no hits.** Details worth recording:

- The three `finally` blocks in the code base (`src/Resolver/TypeExpressionResolver.php:96`, `src/Resolver/NodeExpressionResolver.php:190`, `tests/ConstantExpressionClosuresTest.php:217`) only perform cleanup and do not `return`.
- The single `is_subclass_of()` call (`src/Traits/ReflectionClassLikeTrait.php:853`) passes an object, not a string, so it is unaffected.
- `ReflectionProperty::setValue()` (`src/ReflectionProperty.php:763`) already normalises its arguments to `null`/object before delegating to the parent, so it cannot trigger the new wrong-type deprecation.
- All `define()` usages in the stubs are two-argument calls.

Verified empirically as well: the full suite on 8.6 with `--fail-on-deprecation --fail-on-notice --fail-on-warning --display-deprecations` reports nothing (`phpunit.xml.dist` already sets `error_reporting=E_ALL`).

## 3. CI

The experimental 8.6 job was verified against the last master run ([run 32818096739](https://github.com/goaop/parser-reflection/actions/runs/32818096739)): both 8.6 rows install via setup-php and really execute the suite on the beta (`--ignore-platform-req=php+` correctly relaxes only the upper platform bound). Nothing was broken, so the changes are cosmetic but do address the "surface the result clearly" part of the ticket:

- The job name now reads `PHPUnit tests (PHP 8.6, highest deps) [experimental]` instead of `PHPUnit tests (8.6, highest, ubuntu-latest, true)`.
- Because `continue-on-error` reports a failing experimental row as successful in the checks list, the outcome of the test step is now written to the run summary for experimental rows.
- The 8.6 rows keep `continue-on-error: true` until GA, as required.

## Local results

| Check | Result |
| --- | --- |
| `vendor/bin/phpunit` (PHP 8.5.9) | OK — 13749 tests, 15424 assertions, 134 skipped, 2 incomplete (baseline: 13743 / 133 / 2) |
| `php8.6 vendor/bin/phpunit` (PHP 8.6.0beta1) | OK — 14842 tests, 16608 assertions, 145 skipped, 3 incomplete; also green with `--fail-on-deprecation --fail-on-notice --fail-on-warning` |
| `vendor/bin/phpstan analyse src --no-progress` (level 10) | `[OK] No errors` |

## Finding for a follow-up (not fixed here — out of scope)

While drafting the stub, an unrelated pre-existing parity gap surfaced in `ReflectionMethod::getPrototype()` (`src/ReflectionMethod.php:281`). It searches the parent class first and does not resolve transitively, so for

```php
interface I { public function describe(): string; }
abstract class A implements I { abstract public function describe(): string; }
final class C extends A { public function describe(): string { return ''; } }
```

it returns `A` while native reflection returns `I`. This is not 8.6-specific and would be a behaviour change in `src/`, so the stub was written to avoid the construct instead; it deserves its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy8BcM8ivUEpu8uVm7wADn


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy8BcM8ivUEpu8uVm7wADn)_