### PR TITLE
[PHP 8.6] ReflectionParameter::getDocComment() support

### DIFF
--- a/docs/reflection_parameter.md
+++ b/docs/reflection_parameter.md
@@ -2,5 +2,26 @@ ReflectionParameter
 ==============
 
 The `ReflectionParameter` class reports an information about an parameter. This class is available in the standard PHP, so for any questions, please look at documentation for [`ReflectionParameter`][0]
-  
+
+Parameter doc comments
+---------
+
+PHP 8.6 allows doc comments on parameters and exposes them via `ReflectionParameter::getDocComment(): string|false`.
+This method is implemented statically from the AST, so it is available on every supported PHP version, not only on 8.6:
+
+```php
+function store(
+    /** @param Book[] $books */
+    array $books,
+): void {}
+```
+
+The engine returns the last doc comment that belongs to the parameter declaration in source order, which matches the
+native behaviour for doc comments placed before the parameter, before or after its attributes, before its type and
+inside its default value expression.
+
+Known limitation: a doc comment written *after* the parameter it documents (for example `string $a /** doc */,`)
+is reported by native reflection as belonging to that parameter, but PHP-Parser attaches every comment to the node
+that follows it, so such a trailing comment never reaches the parameter node and `getDocComment()` returns `false`.
+
 [0]: http://php.net/manual/en/class.reflectionparameter.php

--- a/docs/reflection_parameter.md
+++ b/docs/reflection_parameter.md
@@ -20,8 +20,19 @@ The engine returns the last doc comment that belongs to the parameter declaratio
 native behaviour for doc comments placed before the parameter, before or after its attributes, before its type and
 inside its default value expression.
 
-Known limitation: a doc comment written *after* the parameter it documents (for example `string $a /** doc */,`)
-is reported by native reflection as belonging to that parameter, but PHP-Parser attaches every comment to the node
-that follows it, so such a trailing comment never reaches the parameter node and `getDocComment()` returns `false`.
+Known limitation: a doc comment written *after* the parameter it documents is reported by native reflection as
+belonging to that parameter, but PHP-Parser attaches every comment to the node that *follows* it and drops a comment
+that sits before the separating comma altogether. Such a trailing doc comment is therefore always lost:
+
+```php
+function lastParameter(string $a /** doc */) {}
+// native: $a => '/** doc */'                 engine: $a => false
+
+function nextParameter(string $a /** doc */, string $b) {}
+// native: $a => '/** doc */', $b => false    engine: $a => false, $b => false
+```
+
+The comment is not mis-attributed to the following parameter, it simply never reaches the AST. Recovering it is not
+possible from the AST alone, because the position of the separating comma is not available on the parameter nodes.
 
 [0]: http://php.net/manual/en/class.reflectionparameter.php

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -15,6 +15,8 @@ use Go\ParserReflection\Traits\AttributeResolverTrait;
 use Go\ParserReflection\Traits\InternalPropertiesEmulationTrait;
 use Go\ParserReflection\Resolver\NodeExpressionResolver;
 use Go\ParserReflection\Resolver\TypeExpressionResolver;
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp\Concat;
@@ -24,6 +26,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
+use PhpParser\NodeFinder;
 use PhpParser\PrettyPrinter\Standard;
 use ReflectionFunctionAbstract;
 use ReflectionParameter as BaseReflectionParameter;
@@ -327,6 +330,39 @@ final class ReflectionParameter extends BaseReflectionParameter implements NodeA
     public function getDefaultValueExpression(): ?string
     {
         return $this->defaultValueConstExpr;
+    }
+
+    /**
+     * Returns the doc comment attached to this parameter or false if there is no doc comment.
+     *
+     * Doc comments on parameters are a PHP 8.6 feature, exposed natively by
+     * \ReflectionParameter::getDocComment(). PHP-Parser attaches a doc comment to the `Param`
+     * node itself only when the comment directly precedes the parameter declaration. When the
+     * comment sits inside the declaration (for example after an attribute group, after the type
+     * or inside a default value expression) it ends up on a nested node instead. Therefore the
+     * whole parameter sub-tree is scanned and the last doc comment in source order wins, which is
+     * exactly how PHP itself resolves the doc comment of a parameter.
+     */
+    public function getDocComment(): string|false
+    {
+        $lastDocComment     = null;
+        $lastDocCommentPos  = -1;
+
+        $parameterSubTree = (new NodeFinder())->findInstanceOf($this->parameterNode, Node::class);
+        foreach ($parameterSubTree as $node) {
+            foreach ($node->getComments() as $comment) {
+                if (!$comment instanceof Doc) {
+                    continue;
+                }
+                $commentPosition = $comment->getStartFilePos();
+                if ($commentPosition >= $lastDocCommentPos) {
+                    $lastDocCommentPos = $commentPosition;
+                    $lastDocComment    = $comment;
+                }
+            }
+        }
+
+        return $lastDocComment?->getText() ?? false;
     }
 
     /**

--- a/tests/ReflectionParameterTest.php
+++ b/tests/ReflectionParameterTest.php
@@ -343,14 +343,166 @@ class ReflectionParameterTest extends AbstractTestCase
     }
 
     /**
+     * Doc comments on parameters are a PHP 8.6 feature (native ReflectionParameter::getDocComment()),
+     * but the reflection engine resolves them statically on every supported PHP version.
+     *
+     * @param string|array{0: string, 1: string} $functionReference Function name or [class, method] pair
+     */
+    #[DataProvider('parameterDocCommentsDataProvider')]
+    public function testGetDocComment(
+        ReflectionParameter $parsedParameter,
+        string|array $functionReference,
+        string|false $expectedDocComment
+    ): void {
+        $this->assertSame(
+            $expectedDocComment,
+            $parsedParameter->getDocComment(),
+            "getDocComment() for parameter \${$parsedParameter->getName()} should be equal"
+        );
+
+        if (PHP_VERSION_ID >= 80600) {
+            $originalRefParameter = new \ReflectionParameter($functionReference, $parsedParameter->getName());
+            $this->assertSame(
+                $originalRefParameter->getDocComment(),
+                $parsedParameter->getDocComment(),
+                "getDocComment() for parameter \${$parsedParameter->getName()} should match native reflection"
+            );
+        }
+    }
+
+    /**
+     * A doc comment written *after* the parameter it belongs to is a known parity gap.
+     *
+     * PHP itself remembers the last doc comment token seen while the parameter rule is reduced,
+     * therefore a trailing comment still belongs to the preceding parameter. PHP-Parser instead
+     * attaches every comment to the node that *follows* it, so a trailing comment never reaches
+     * the `Param` node and the engine reports `false`.
+     */
+    public function testTrailingDocCommentIsAKnownParityGap(): void
+    {
+        $parsedFunction  = self::getStub86Namespace()->getFunction('parameterWithTrailingDocComment86');
+        $parsedParameter = $parsedFunction->getParameters()[0];
+
+        $this->assertSame('trailing', $parsedParameter->getName());
+        $this->assertFalse($parsedParameter->getDocComment());
+
+        if (PHP_VERSION_ID >= 80600) {
+            $originalRefParameter = new \ReflectionParameter($parsedFunction->getName(), 'trailing');
+            $this->assertSame(
+                '/** trailing doc comment, attached to the parameter by the engine only */',
+                $originalRefParameter->getDocComment(),
+                'Native reflection is expected to still report the trailing doc comment'
+            );
+        }
+    }
+
+    /**
+     * Provides list in the form [ReflectionParameter, function reference, expected doc comment]
+     */
+    public static function parameterDocCommentsDataProvider(): \Generator
+    {
+        $expectedDocComments = [
+            'parametersWithDocComments86' => [
+                'documented'                 => '/** @param string $documented simple leading doc comment */',
+                'undocumented'               => false,
+                'blockCommented'             => false,
+                'lineCommented'              => false,
+                'variadic'                   => '/** @param array<int> $variadic variadic doc comment */',
+            ],
+            'parametersWithReferencesAndAttributes86' => [
+                'byReference'                => '/** @param array<string> $byReference by-reference doc comment */',
+                'docBeforeAttribute'         => '/** doc comment placed before the attribute */',
+                'docAfterAttribute'          => '/** doc comment placed after the attribute */',
+                'lastDocCommentWins'         => '/** last doc comment wins */',
+                'docCommentThenBlockComment' => '/** doc comment followed by a regular comment */',
+            ],
+            'parametersWithDefaultsAndTypes86' => [
+                'nullableWithDefault'        => '/** @param string|null $nullableWithDefault nullable doc comment */',
+                'unionTyped'                 => '/** @param int|float $unionTyped union type doc comment */',
+                'arrayDefault'               => '/** @param array<mixed> $arrayDefault doc comment for array default */',
+            ],
+        ];
+
+        $expectedMethodDocComments = [
+            'ClassWithDocumentedParameters86::__construct' => [
+                'promoted'                   => '/** @var string promoted property doc comment */',
+                'promotedProtected'          => '/** @var int promoted protected property doc comment */',
+                'promotedUndocumented'       => false,
+            ],
+            'ClassWithDocumentedParameters86::documentedMethod' => [
+                'first'                      => false,
+                'second'                     => '/** @param string $second method parameter doc comment */',
+            ],
+            'ClassWithDocumentedParameters86::documentedStaticMethod' => [
+                'instance'                   => '/** @param self $instance static method parameter doc comment */',
+            ],
+        ];
+
+        $parsedNamespace = self::getStub86Namespace();
+
+        foreach ($expectedDocComments as $functionName => $expectedParameters) {
+            $parsedFunction = $parsedNamespace->getFunction($functionName);
+            foreach ($parsedFunction->getParameters() as $parsedParameter) {
+                $parameterName = $parsedParameter->getName();
+                if (!array_key_exists($parameterName, $expectedParameters)) {
+                    throw new \LogicException("Missing expectation for {$functionName}(\${$parameterName})");
+                }
+                yield "{$functionName}(\${$parameterName})" => [
+                    $parsedParameter,
+                    $parsedFunction->getName(),
+                    $expectedParameters[$parameterName],
+                ];
+            }
+        }
+
+        foreach ($expectedMethodDocComments as $methodReference => $expectedParameters) {
+            [$className, $methodName] = explode('::', $methodReference);
+            $parsedClass  = $parsedNamespace->getClass('Go\ParserReflection\Stub\\' . $className);
+            $parsedMethod = $parsedClass->getMethod($methodName);
+            foreach ($parsedMethod->getParameters() as $parsedParameter) {
+                $parameterName = $parsedParameter->getName();
+                if (!array_key_exists($parameterName, $expectedParameters)) {
+                    throw new \LogicException("Missing expectation for {$methodReference}(\${$parameterName})");
+                }
+                yield "{$methodReference}(\${$parameterName})" => [
+                    $parsedParameter,
+                    [$parsedClass->getName(), $methodName],
+                    $expectedParameters[$parameterName],
+                ];
+            }
+        }
+    }
+
+    /**
+     * Parses (and loads) the stub file with documented parameters
+     */
+    private static function getStub86Namespace(): ReflectionFileNamespace
+    {
+        $fileName       = __DIR__ . '/Stub/FileWithParameters86.php';
+        $reflectionFile = new ReflectionFile($fileName);
+
+        // The file only contains ordinary comments, so it can be safely loaded on any PHP version
+        include_once $fileName;
+
+        return $reflectionFile->getFileNamespace('Go\ParserReflection\Stub');
+    }
+
+    /**
      * @inheritDoc
      */
     static protected function getGettersToCheck(): array
     {
-        return [
+        $getters = [
             'isOptional', 'isPassedByReference', 'isDefaultValueAvailable',
             'getPosition', 'canBePassedByValue', 'allowsNull', 'getDefaultValue', 'getDefaultValueConstantName',
             'isDefaultValueConstant', 'isVariadic', 'isPromoted', 'hasType', '__toString'
         ];
+
+        if (PHP_VERSION_ID >= 80600) {
+            // Native ReflectionParameter::getDocComment() only exists since PHP 8.6
+            $getters[] = 'getDocComment';
+        }
+
+        return $getters;
     }
 }

--- a/tests/ReflectionParameterTest.php
+++ b/tests/ReflectionParameterTest.php
@@ -389,10 +389,44 @@ class ReflectionParameterTest extends AbstractTestCase
         if (PHP_VERSION_ID >= 80600) {
             $originalRefParameter = new \ReflectionParameter($parsedFunction->getName(), 'trailing');
             $this->assertSame(
-                '/** trailing doc comment, attached to the parameter by the engine only */',
+                '/** trailing doc comment on the last parameter of the list */',
                 $originalRefParameter->getDocComment(),
                 'Native reflection is expected to still report the trailing doc comment'
             );
+        }
+    }
+
+    /**
+     * The same known parity gap when another parameter follows the trailing doc comment.
+     *
+     * PHP-Parser discards a comment that sits between the end of a parameter and the separating
+     * comma altogether: it reaches neither the documented parameter nor the following one, so the
+     * engine reports `false` for both. Native reflection instead reports the comment for the
+     * parameter it follows. Both sides are pinned so a future change in php-src or in PHP-Parser
+     * is noticed immediately.
+     */
+    public function testTrailingDocCommentIsLostWhenAnotherParameterFollows(): void
+    {
+        $parsedFunction               = self::getStub86Namespace()->getFunction('twoParametersWithTrailingDocComment86');
+        [$parsedFirst, $parsedSecond] = $parsedFunction->getParameters();
+
+        $this->assertSame('first', $parsedFirst->getName());
+        $this->assertSame('second', $parsedSecond->getName());
+
+        // The comment is dropped by PHP-Parser, so it is not mis-attributed to the next parameter
+        $this->assertFalse($parsedFirst->getDocComment());
+        $this->assertFalse($parsedSecond->getDocComment());
+
+        if (PHP_VERSION_ID >= 80600) {
+            $originalFirst  = new \ReflectionParameter($parsedFunction->getName(), 'first');
+            $originalSecond = new \ReflectionParameter($parsedFunction->getName(), 'second');
+
+            // Native reflection reports the comment for the parameter that precedes it
+            $this->assertSame(
+                '/** trailing doc comment written after the first parameter */',
+                $originalFirst->getDocComment()
+            );
+            $this->assertFalse($originalSecond->getDocComment());
         }
     }
 

--- a/tests/Stub/FileWithParameters86.php
+++ b/tests/Stub/FileWithParameters86.php
@@ -99,11 +99,25 @@ class ClassWithDocumentedParameters86
 
 /**
  * The doc comment below is placed *after* the parameter it documents and is a known parity gap:
- * PHP-Parser attaches such a trailing comment to the following node instead of to the parameter.
+ * PHP-Parser attaches such a trailing comment to the following node instead of to the parameter,
+ * so nothing reaches the last parameter of the list and the engine reports `false` for it.
  *
  * @see \Go\ParserReflection\ReflectionParameterTest::testTrailingDocCommentIsAKnownParityGap()
  */
 function parameterWithTrailingDocComment86(
-    string $trailing /** trailing doc comment, attached to the parameter by the engine only */
+    string $trailing /** trailing doc comment on the last parameter of the list */
+) {
+}
+
+/**
+ * The same known parity gap, but with a parameter following the trailing doc comment: native
+ * reflection reports the comment for `$first`, while PHP-Parser discards a comment placed before
+ * the separating comma entirely, so neither `$first` nor `$second` receives it.
+ *
+ * @see \Go\ParserReflection\ReflectionParameterTest::testTrailingDocCommentIsLostWhenAnotherParameterFollows()
+ */
+function twoParametersWithTrailingDocComment86(
+    string $first /** trailing doc comment written after the first parameter */,
+    string $second
 ) {
 }

--- a/tests/Stub/FileWithParameters86.php
+++ b/tests/Stub/FileWithParameters86.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+/**
+ * Parser Reflection API
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\ParserReflection\Stub;
+
+use Attribute;
+
+/**
+ * Doc comments on parameters are a PHP 8.6 feature, but syntactically they are ordinary comments,
+ * therefore this file is parsable (and includable) on every supported PHP version.
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class ParameterMarker86
+{
+    public function __construct(public readonly string $note = '')
+    {
+    }
+}
+
+/**
+ * Doc comment of the function itself, it must never leak into the first parameter.
+ */
+function parametersWithDocComments86(
+    /** @param string $documented simple leading doc comment */
+    string $documented,
+    int $undocumented,
+    /* not a doc comment, only a regular block comment */
+    string $blockCommented = 'default',
+    // not a doc comment, only a line comment
+    string $lineCommented = 'default',
+    /** @param array<int> $variadic variadic doc comment */
+    int ...$variadic
+) {
+}
+
+function parametersWithReferencesAndAttributes86(
+    /** @param array<string> $byReference by-reference doc comment */
+    array &$byReference,
+    /** doc comment placed before the attribute */
+    #[ParameterMarker86('before')]
+    string $docBeforeAttribute,
+    #[ParameterMarker86('after')]
+    /** doc comment placed after the attribute */
+    string $docAfterAttribute,
+    /** first doc comment that is superseded */
+    /** last doc comment wins */
+    string $lastDocCommentWins,
+    /** doc comment followed by a regular comment */
+    /* regular comment does not reset the doc comment */
+    string $docCommentThenBlockComment
+) {
+}
+
+function parametersWithDefaultsAndTypes86(
+    /** @param string|null $nullableWithDefault nullable doc comment */
+    ?string $nullableWithDefault = null,
+    /** @param int|float $unionTyped union type doc comment */
+    int|float $unionTyped = 0,
+    /** @param array<mixed> $arrayDefault doc comment for array default */
+    array $arrayDefault = [1, 2, 3]
+) {
+}
+
+class ClassWithDocumentedParameters86
+{
+    public function __construct(
+        /** @var string promoted property doc comment */
+        public readonly string $promoted,
+        /** @var int promoted protected property doc comment */
+        protected int $promotedProtected = 0,
+        private ?array $promotedUndocumented = null
+    ) {
+    }
+
+    /**
+     * Doc comment of the method itself, it must never leak into the first parameter.
+     */
+    public function documentedMethod(
+        int $first,
+        /** @param string $second method parameter doc comment */
+        string $second
+    ): void {
+    }
+
+    public static function documentedStaticMethod(
+        /** @param self $instance static method parameter doc comment */
+        self $instance
+    ): void {
+    }
+}
+
+/**
+ * The doc comment below is placed *after* the parameter it documents and is a known parity gap:
+ * PHP-Parser attaches such a trailing comment to the following node instead of to the parameter.
+ *
+ * @see \Go\ParserReflection\ReflectionParameterTest::testTrailingDocCommentIsAKnownParityGap()
+ */
+function parameterWithTrailingDocComment86(
+    string $trailing /** trailing doc comment, attached to the parameter by the engine only */
+) {
+}


### PR DESCRIPTION
Refs #221 (part of epic #219).

## What

PHP 8.6 allows doc comments on function/method parameters and exposes them through the new native `ReflectionParameter::getDocComment(): string|false`. This PR implements the same method statically from the AST, so it is available on **every** supported PHP version, not only on 8.6.

## Changes

- **`src/ReflectionParameter.php`** — new `getDocComment(): string|false` (signature-compatible with the PHP 8.6 parent; on 8.5 it is simply an extra method, the 8.5 parent has none).
- **`tests/Stub/FileWithParameters86.php`** — new stub with the doc-comment matrix. It contains only ordinary comments, so it parses *and* loads on every supported PHP version and is included by the test to allow native comparison.
- **`tests/ReflectionParameterTest.php`** — dedicated `testGetDocComment()` parity test, two tests pinning the known trailing-comment gap, plus `getDocComment` added to the generic getter parity matrix when running on PHP >= 8.6.
- **`docs/reflection_parameter.md`** — documents the method and the known limitation.

## Resolution strategy

PHP-Parser attaches a doc comment to the `Param` node itself **only** when the comment directly precedes the parameter declaration. When the comment sits *inside* the declaration it ends up on a nested node instead — verified with the bundled `nikic/php-parser` v5.8.0:

| source | node that receives the comment |
| --- | --- |
| `/** doc */ string $a` | `Param` |
| `/** doc */ #[Attr] string $a` | `Param` |
| `#[Attr] /** doc */ string $a` | `Identifier` (the type) |
| `#[A] /** doc */ #[B] string $a` | the second `AttributeGroup` |
| `int $a = /** doc */ 5` | the default value expression |

Therefore the implementation scans the whole parameter sub-tree and picks the **last doc comment in source order**, which is exactly how PHP itself resolves a parameter's doc comment (its lexer remembers the most recent doc-comment token). Non-doc comments (`/* … */`, `// …`) never reset it, and the last of several doc comments wins — both verified against the 8.6 binary.

## Verified parity against PHP 8.6.0beta1

Every parameter in the new stub returns byte-for-byte the same value as native reflection: leading doc comments, variadic, by-reference, nullable, union-typed, defaults (scalar/array), promoted constructor properties (public/protected), static methods, doc comment before *and* after attributes, several consecutive doc comments, doc comment followed by a block comment, plus the negative cases (no comment, block comment, line comment). Function/method doc comments correctly do **not** leak into the first parameter.

Also checked: native `var_dump()`/`(array)` cast of `ReflectionParameter` on 8.6 still exposes only `name`, so `__debugInfo()` / `InternalPropertiesEmulationTrait` needed no change. `testCoverAllMethods` for `ReflectionParameter` now passes on 8.6 (it would otherwise report `getDocComment` as missing).

## Known parity gap

A doc comment written **after** the parameter it documents is reported by native reflection as belonging to that parameter, because PHP records the last doc-comment token seen while reducing the parameter rule. PHP-Parser attaches every comment to the node that *follows* it, and a comment sitting between the end of a parameter and the separating comma is discarded entirely, so such a trailing comment never reaches the AST at all:

```php
function lastParameter(string $a /** doc */) {}
// native: $a => '/** doc */'                 engine: $a => false

function nextParameter(string $a /** doc */, string $b) {}
// native: $a => '/** doc */', $b => false    engine: $a => false, $b => false
```

Note that the comment is **not** mis-attributed to the following parameter — it is simply lost. This position is pathological and cannot be recovered without access to the token stream (the comma position is not available on the AST). It is documented in `docs/reflection_parameter.md`, in the stub, and pinned from both sides by `testTrailingDocCommentIsAKnownParityGap()` and `testTrailingDocCommentIsLostWhenAnotherParameterFollows()`, which also assert the divergent native behaviour on 8.6 so a future change in php-src or PHP-Parser is noticed.

## Local results

| check | result |
| --- | --- |
| `vendor/bin/phpunit` (PHP 8.5.9) | OK — 13764 tests, 15417 assertions, 133 skipped, 2 incomplete (pre-existing, `ReflectionPropertyTest::testCoverAllMethods`) |
| `php8.6 vendor/bin/phpunit` (PHP 8.6.0beta1) | OK — 13892 tests, 15567 assertions, 133 skipped, 2 incomplete (same pre-existing one) |
| `vendor/bin/phpstan analyse src --no-progress` (level 10) | `[OK] No errors` — no `phpstan.neon` changes needed |

Baseline on `master` was 13743 tests on 8.5; the new tests add 21 cases on 8.5 and 149 on 8.6 (the extra ones come from `getDocComment` joining the generic getter parity matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy8BcM8ivUEpu8uVm7wADn