### PR TITLE
[PHP 8.6] Internal functions with #[\Deprecated]: native-fallback parity coverage

### DIFF
--- a/tests/DeprecatedAndFunctionLikeGapsTest.php
+++ b/tests/DeprecatedAndFunctionLikeGapsTest.php
@@ -53,6 +53,23 @@ class DeprecatedAndFunctionLikeGapsTest extends TestCase
         'php84ImportedDeprecatedFunction',
     ];
 
+    /**
+     * Internal function that receives the #[\Deprecated] attribute in PHP 8.6 only
+     *
+     * @see https://github.com/goaop/parser-reflection/issues/215
+     */
+    private const PHP86_DEPRECATED_INTERNAL_FUNCTION = 'strcoll';
+
+    /**
+     * Internal function that already carries the #[\Deprecated] attribute long before PHP 8.6
+     */
+    private const LEGACY_DEPRECATED_INTERNAL_FUNCTION = 'utf8_encode';
+
+    /**
+     * Internal function that is not deprecated at all, used as a negative control
+     */
+    private const PLAIN_INTERNAL_FUNCTION = 'strlen';
+
     private string $stubFileName;
 
     protected function setUp(): void
@@ -214,6 +231,112 @@ class DeprecatedAndFunctionLikeGapsTest extends TestCase
         $this->assertSame($nativeMethod->isStatic(), $parsedMethod->isStatic());
         $this->assertSame($nativeMethod->isPublic(), $parsedMethod->isPublic());
         $this->assertSame($nativeMethod->isDeprecated(), $parsedMethod->isDeprecated());
+    }
+
+    /**
+     * Internal functions have no source file, so the AST parser can never reflect them and the
+     * native reflection is always used for them instead.
+     */
+    public function testInternalFunctionsAreReflectedByTheNativeFallback(): void
+    {
+        $parsedNamespace   = $this->getStubFileNamespace();
+        $internalFunctions = [
+            self::PHP86_DEPRECATED_INTERNAL_FUNCTION,
+            self::LEGACY_DEPRECATED_INTERNAL_FUNCTION,
+            self::PLAIN_INTERNAL_FUNCTION,
+        ];
+
+        foreach ($internalFunctions as $functionName) {
+            $this->assertTrue(function_exists($functionName), "Function {$functionName}() should be available");
+
+            $nativeFunction = new \ReflectionFunction($functionName);
+            $this->assertTrue($nativeFunction->isInternal(), "Function {$functionName}() should be internal");
+            $this->assertFalse(
+                $nativeFunction->getFileName(),
+                "Function {$functionName}() has no source file, therefore it can not be parsed"
+            );
+            $this->assertFalse(
+                $parsedNamespace->hasFunction($functionName),
+                "Function {$functionName}() should never be resolved to a parsed reflection"
+            );
+        }
+
+        // Parsed functions are always user-defined, so internal ones can only be served by the native
+        // reflection, and the parsed one is a drop-in replacement for the native \ReflectionFunction
+        $parsedFunction = $parsedNamespace->getFunction('php84PlainFunction');
+        $this->assertInstanceOf(\ReflectionFunction::class, $parsedFunction);
+        $this->assertFalse($parsedFunction->isInternal());
+        $this->assertTrue($parsedFunction->isUserDefined());
+    }
+
+    /**
+     * The #[\Deprecated] status of internal functions is reflected on every supported runtime,
+     * the mechanism is not specific to the functions deprecated in PHP 8.6.
+     */
+    public function testDeprecatedInternalFunctionIsReflectedOnEveryRuntime(): void
+    {
+        $functionName   = self::LEGACY_DEPRECATED_INTERNAL_FUNCTION;
+        $nativeFunction = new \ReflectionFunction($functionName);
+
+        $this->assertTrue($nativeFunction->isDeprecated(), "Function {$functionName}() is deprecated since PHP 8.2");
+        $this->assertSame('8.2', $this->getDeprecatedAttributeArguments($nativeFunction)['since']);
+        $this->assertStringContainsString('deprecated', $nativeFunction->__toString());
+
+        $plainFunction = new \ReflectionFunction(self::PLAIN_INTERNAL_FUNCTION);
+        $this->assertFalse($plainFunction->isDeprecated());
+        $this->assertSame([], $plainFunction->getAttributes(\Deprecated::class));
+        $this->assertStringNotContainsString('deprecated', $plainFunction->__toString());
+    }
+
+    public function testInternalFunctionDeprecatedInPhp86IsReflectedWithItsAttributePayload(): void
+    {
+        if (PHP_VERSION_ID < 80600) {
+            $this->markTestSkipped('Internal function strcoll() is deprecated since PHP 8.6 only');
+        }
+
+        $nativeFunction = new \ReflectionFunction(self::PHP86_DEPRECATED_INTERNAL_FUNCTION);
+
+        $this->assertTrue($nativeFunction->isDeprecated());
+        $arguments = $this->getDeprecatedAttributeArguments($nativeFunction);
+        $this->assertSame('8.6', $arguments['since']);
+        $this->assertSame('use Collator::compare() instead', $arguments['message']);
+        $this->assertStringContainsString('deprecated', $nativeFunction->__toString());
+
+        $deprecated = $nativeFunction->getAttributes(\Deprecated::class)[0]->newInstance();
+        $this->assertInstanceOf(\Deprecated::class, $deprecated);
+        $this->assertSame('8.6', $deprecated->since);
+    }
+
+    public function testInternalFunctionDeprecatedInPhp86IsNotDeprecatedBefore(): void
+    {
+        if (PHP_VERSION_ID >= 80600) {
+            $this->markTestSkipped('Internal function strcoll() is deprecated since PHP 8.6');
+        }
+
+        $nativeFunction = new \ReflectionFunction(self::PHP86_DEPRECATED_INTERNAL_FUNCTION);
+
+        $this->assertFalse($nativeFunction->isDeprecated());
+        $this->assertSame([], $nativeFunction->getAttributes(\Deprecated::class));
+        $this->assertStringNotContainsString('deprecated', $nativeFunction->__toString());
+    }
+
+    /**
+     * Returns the arguments of the single #[\Deprecated] attribute of the given function
+     *
+     * @return array<string, string>
+     */
+    private function getDeprecatedAttributeArguments(\ReflectionFunction $function): array
+    {
+        $functionName = $function->getName();
+        $attributes   = $function->getAttributes(\Deprecated::class);
+        $this->assertCount(1, $attributes, "Function {$functionName}() should have one #[\\Deprecated] attribute");
+        $this->assertSame(\Deprecated::class, $attributes[0]->getName());
+
+        /** @var array<string, string> $arguments */
+        $arguments = $attributes[0]->getArguments();
+        $this->assertArrayHasKey('since', $arguments, "Function {$functionName}() should report the deprecation version");
+
+        return $arguments;
     }
 
     /**


### PR DESCRIPTION
Refs #215

## Outcome: confirmed, no production code change needed

Verified on a local PHP 8.6.0beta1 build that `strcoll()` and the other internal functions newly annotated in 8.6 are reflected correctly, and that no gap exists in this library.

### Findings

**The fallback is structural, not conditional.** `Go\ParserReflection\ReflectionFunction` is constructed exclusively from a `PhpParser\Node\Stmt\Function_` AST node (`ReflectionFileNamespace::findFunctions()` is the only construction site in `src/`). Internal functions have no source file (`getFileName()` is `false`), so they can never enter the parsing path — a consumer asking for `strcoll()` necessarily gets a plain `\ReflectionFunction`. Since the parsed class extends the native one, code type-hinting `\ReflectionFunction` accepts both transparently. Consistently, `ReflectionFunctionLikeTrait::isInternal()` hard-returns `false` and `isUserDefined()` hard-returns `true`.

**Native reflection reports everything as expected on 8.6.** Probed directly on the 8.6 binary:

- `(new \ReflectionFunction('strcoll'))->isDeprecated()` → `true` (it is `false` on 8.5)
- `getAttributes(\Deprecated::class)` → one attribute, `getName()` is `Deprecated`, arguments `['message' => 'use Collator::compare() instead', 'since' => '8.6']`, and `newInstance()` yields a real `\Deprecated` instance
- `__toString()` → `Function [ <internal, deprecated:standard> function strcoll ] { ... }`

For scale: 37 internal functions carry `#[\Deprecated]` on 8.5 versus 55 on 8.6, so the downstream `goaop/framework` proxy-generator diff is the expected consequence of the engine change rather than a reflection defect here.

**No deprecation notices are emitted by reflecting these functions** — `isDeprecated()`, `getAttributes()` and `__toString()` are all side-effect free, so the added tests are safe under strict error reporting.

### Coverage added

Four test methods in `tests/DeprecatedAndFunctionLikeGapsTest.php`, alongside the existing PHP 8.4 `#[\Deprecated]` coverage (tests only, no `src/` changes):

- `testInternalFunctionsAreReflectedByTheNativeFallback()` — runtime-agnostic: internal functions have no file name and are never resolved to a parsed reflection, while a parsed function stays user-defined and remains a drop-in `\ReflectionFunction`.
- `testDeprecatedInternalFunctionIsReflectedOnEveryRuntime()` — runtime-agnostic: `utf8_encode()` (deprecated since 8.2) reports its attribute payload and its `deprecated` marker in `__toString()`, with `strlen()` as a negative control. This proves the mechanism is not specific to 8.6.
- `testInternalFunctionDeprecatedInPhp86IsReflectedWithItsAttributePayload()` — guarded by `PHP_VERSION_ID >= 80600`: `strcoll()` reports deprecated with `since: '8.6'` and `message: 'use Collator::compare() instead'`.
- `testInternalFunctionDeprecatedInPhp86IsNotDeprecatedBefore()` — guarded by `PHP_VERSION_ID < 80600`: `strcoll()` reports no deprecation and no attribute, pinning the transition from the other side.

Each version-specific test is skipped (not failed) on the runtime it does not target, so the suite stays green on both.

### Unrelated observation (not addressed here)

While probing, one pre-existing difference surfaced in the parsed attribute layer, unrelated to internal functions and to this issue: for a user-land `#[\Deprecated(message: '...', since: '4.0')]`, native `ReflectionAttribute::getArguments()` returns the named arguments keyed by name, whereas `Go\ParserReflection\ReflectionAttribute::getArguments()` returns them positionally. It affects every attribute with named arguments, not just `\Deprecated`. Left untouched to keep this verification ticket minimal — worth its own issue if wanted.

### Local validation

| Check | Result |
| --- | --- |
| `vendor/bin/phpunit` (PHP 8.5.9) | OK — 13747 tests, 15423 assertions, 134 skipped, 2 incomplete |
| `php8.6 vendor/bin/phpunit` (PHP 8.6.0beta1) | OK — 13747 tests, 15429 assertions, 134 skipped, 3 incomplete |
| `vendor/bin/phpstan analyse src --no-progress` (level 10) | `[OK] No errors` |

Baseline on `master` (PHP 8.5) was 13743 tests / 133 skipped; the four new tests account for the difference, one of which is always skipped on a given runtime by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy8BcM8ivUEpu8uVm7wADn